### PR TITLE
refactor: 長押し時間のハードコードを止め、変数を切り替えるだけで容易に設定できるように変更

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/UserActionManager.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/UserActionManager.swift
@@ -15,7 +15,7 @@ open class UserActionManager: @unchecked Sendable {
     public init() {}
     @MainActor open func registerAction(_ action: ActionType, variableStates: VariableStates) {}
     @MainActor open func registerActions(_ actions: [ActionType], variableStates: VariableStates) {}
-    @MainActor open func reserveLongPressAction(_ action: LongpressActionType, variableStates: VariableStates) {}
+    @MainActor open func reserveLongPressAction(_ action: LongpressActionType, taskStartDuration: Double, variableStates: VariableStates) {}
     @MainActor open func registerLongPressActionEnd(_ action: LongpressActionType) {}
     @MainActor open func setTextDocumentProxy(_ proxy: AnyTextDocumentProxy) {}
     @MainActor open func notifyComplete(_ candidate: any ResultViewItemData, variableStates: VariableStates) {}

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -38,6 +38,9 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
     private func label(width: CGFloat) -> some View {
         model.label(width: keyViewWidth, states: variableStates)
     }
+    private var longpressDuration: TimeInterval {
+        0.4
+    }
 
     public var body: some View {
         label(width: keyViewWidth)
@@ -58,7 +61,7 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
                             isPressed = true
                             pressStartDate = Date()
                             model.feedback(variableStates: variableStates)
-                            action.reserveLongPressAction(self.model.longPressActions(variableStates: variableStates), variableStates: variableStates)
+                            action.reserveLongPressAction(self.model.longPressActions(variableStates: variableStates), taskStartDuration: self.longpressDuration, variableStates: variableStates)
                         } touchMovedCallBack: { state  in
                             if state.distance > 15 {
                                 isPressed = false
@@ -68,7 +71,7 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
                         } touchUpCallBack: {state in
                             isPressed = false
                             action.registerLongPressActionEnd(self.model.longPressActions(variableStates: variableStates))
-                            if Date().timeIntervalSince(pressStartDate) < 0.4 && state.distance < 30 {
+                            if Date().timeIntervalSince(pressStartDate) < longpressDuration && state.distance < 30 {
                                 action.registerActions(self.model.pressActions(variableStates: variableStates), variableStates: variableStates)
                                 self.model.additionalOnPress(variableStates: variableStates)
                             }

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -366,19 +366,20 @@ final class KeyboardActionManager: UserActionManager, @unchecked Sendable {
     /// 長押しを予約する関数。
     /// - Parameters:
     ///   - action: 長押しで起こる動作のタイプ。
-    override func reserveLongPressAction(_ action: LongpressActionType, variableStates: VariableStates) {
+    override func reserveLongPressAction(_ action: LongpressActionType, taskStartDuration: Double, variableStates: VariableStates) {
         if tasks.contains(where: {$0.type == action}) {
             return
         }
+        let nanoseconds = UInt64(taskStartDuration * 1_000_000_000)
         let startTask = Task {
-            try await Task.sleep(nanoseconds: 0_400_000_000)
+            try await Task.sleep(nanoseconds: nanoseconds)
             action.start.first?.feedback(variableStates: variableStates, extension: AzooKeyKeyboardViewExtension.self)
             self.registerActions(action.start, variableStates: variableStates)
         }
         self.tasks.append((type: action, task: startTask))
 
         let repeatTask = Task {
-            try await Task.sleep(nanoseconds: 0_400_000_000)
+            try await Task.sleep(nanoseconds: nanoseconds)
             while !Task.isCancelled {
                 action.repeat.first?.feedback(variableStates: variableStates, extension: AzooKeyKeyboardViewExtension.self)
                 self.registerActions(action.repeat, variableStates: variableStates)


### PR DESCRIPTION
Related to #500, but not resolve

長押し判定の時間は0.4秒を前提にコードを作っていたが、これに関連する変数を整理し（原理的には）切り替えられるようにした。