### PR TITLE
refactor: `overlay`と`background`でdeprecated APIを使っている部分を修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -232,11 +232,11 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                 Circle()
                     .fill(Color.blue)
                     .frame(width: r, height: r)
-                    .overlay(
+                    .overlay {
                         Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
                             .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
-                    )
+                    }
                     .gesture(moveGesture)
                 Button {
                     KeyboardFeedback<Extension>.reset()
@@ -249,15 +249,15 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                     self.bottom_right_edge = (.init(x: initialSize.width, y: initialSize.height), .init(x: initialSize.width, y: initialSize.height))
                     self.initialPosition = .zero
                     self.updateUserDefaults()
-                }label: {
+                } label: {
                     Circle()
                         .fill(Color.red)
                         .frame(width: r, height: r)
-                        .overlay(
+                        .overlay {
                             Image(systemName: "arrow.triangle.2.circlepath")
                                 .foregroundStyle(.white)
                                 .font(Font.system(size: r * 0.5))
-                        )
+                        }
                 }
                 Button {
                     if self.position == .zero && self.size == self.initialSize {
@@ -265,15 +265,15 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                     } else {
                         variableStates.setResizingMode(.onehanded)
                     }
-                }label: {
+                } label: {
                     Circle()
                         .fill(Color.blue)
                         .frame(width: r, height: r)
-                        .overlay(
+                        .overlay {
                             Image(systemName: "checkmark")
                                 .foregroundStyle(.white)
                                 .font(Font.system(size: r * 0.5))
-                        )
+                        }
                 }
             }
         }
@@ -329,29 +329,29 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
             let r = min(data.max * 0.7, max)
             let button1 = Button {
                 variableStates.setResizingMode(.resizing)
-            }label: {
+            } label: {
                 Circle()
                     .fill(Color.blue)
                     .frame(width: r, height: r)
-                    .overlay(
+                    .overlay {
                         Image(systemName: "aspectratio")
                             .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
-                    )
+                    }
             }
             .frame(width: r, height: r)
 
             let button2 = Button {
                 variableStates.setResizingMode(.fullwidth)
-            }label: {
+            } label: {
                 Circle()
                     .fill(Color.blue)
                     .frame(width: r, height: r)
-                    .overlay(
+                    .overlay {
                         Image(systemName: "arrow.up.backward.and.arrow.down.forward")
                             .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
-                    )
+                    }
             }
             .frame(width: r, height: r)
 
@@ -370,11 +370,11 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                 Circle()
                     .fill(Color.red)
                     .frame(width: r, height: r)
-                    .overlay(
+                    .overlay {
                         Image(systemName: "arrow.triangle.2.circlepath")
                             .foregroundStyle(.white)
                             .font(Font.system(size: r * 0.5))
-                    )
+                    }
             }
 
             switch data.stack {
@@ -416,7 +416,9 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                     .frame(width: size.width, height: size.height)
             }
             .disabled(true)
-            .overlay(ResizingRect<Extension>(size: $size, position: $position, initialSize: initialSize))
+            .overlay {
+                ResizingRect<Extension>(size: $size, position: $position, initialSize: initialSize)
+            }
             .frame(width: size.width, height: size.height)
             .offset(x: position.x, y: position.y)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -54,7 +54,7 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
                     .frame(width: keyViewWidth, height: keyViewHeight)
             )
             .frame(width: keyViewWidth, height: keyViewHeight)
-            .overlay(
+            .overlay {
                 Group {
                     if !(model is SimpleChangeKeyboardKeyModel<Extension> && SemiStaticStates.shared.needsInputModeSwitchKey) {
                         TouchDownAndTouchUpGestureView {
@@ -81,7 +81,7 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
                 .onDisappear {
                     action.registerLongPressActionEnd(self.model.longPressActions(variableStates: variableStates))
                 }
-            )
+            }
             .frame(width: keyViewWidth, height: keyViewHeight)
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -44,7 +44,7 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
 
     public var body: some View {
         label(width: keyViewWidth)
-            .background(
+            .background {
                 RoundedRectangle(cornerRadius: 6)
                     .strokeAndFill(
                         fillContent: isPressed ? model.backGroundColorWhenPressed(theme: theme) : model.unpressedKeyColorType.color(states: variableStates, theme: theme),
@@ -52,7 +52,7 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
                         lineWidth: theme.borderWidth
                     )
                     .frame(width: keyViewWidth, height: keyViewHeight)
-            )
+            }
             .frame(width: keyViewWidth, height: keyViewHeight)
             .overlay {
                 Group {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -242,7 +242,9 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
             .gesture(gesture)
             .compositingGroup()
             .shadow(color: theme.keyShadow?.color.color ?? .clear, radius: theme.keyShadow?.radius ?? 0, x: theme.keyShadow?.x ?? 0, y: theme.keyShadow?.y ?? 0)
-            .overlay(self.label(width: keySize.width))
+            .overlay {
+                self.label(width: keySize.width)
+            }
     }
 
     func longFlickReserve(_ direction: FlickDirection) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ReflectStyleCursorBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ReflectStyleCursorBar.swift
@@ -242,7 +242,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                     .font(symbolFont(size: 18))
                     .foregroundStyle(symbolsColor)
                     .padding()
-                    .overlay(
+                    .overlay {
                         TouchDownAndTouchUpGestureView {
                             self.startLongPress(offset: -1)
                         } touchMovedCallBack: { state in
@@ -260,7 +260,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                                 KeyboardFeedback<Extension>.tabOrOtherKey()
                             }
                         }
-                    )
+                    }
                 Spacer()
                 Text(verbatim: "│")
                     .font(.system(size: fontSize + 4))
@@ -271,7 +271,7 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                     .font(symbolFont(size: 18))
                     .foregroundStyle(symbolsColor)
                     .padding()
-                    .overlay(
+                    .overlay {
                         TouchDownAndTouchUpGestureView {
                             self.startLongPress(offset: 1)
                         } touchMovedCallBack: { state in
@@ -288,14 +288,16 @@ struct ReflectStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension
                                 KeyboardFeedback<Extension>.tabOrOtherKey()
                             }
                         }
-                    )
+                    }
             }
         }
     }
 
     var body: some View {
         background
-            .overlay(foregroundButtons)
+            .overlay {
+                foregroundButtons
+            }
             .onAppear {
                 cursorBarState.updateItemCount(viewWidth: viewWidth, itemWidth: itemWidth)
                 let surroundingText = variableStates.surroundingText

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/SliderStyleCursorBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/SliderStyleCursorBar.swift
@@ -148,7 +148,7 @@ struct SliderStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension>
         RadialGradient(gradient: Gradient(colors: [centerColor, edgeColor]), center: .center, startRadius: 1, endRadius: 200)
             .cornerRadius(20)
             .gesture(swipeGesture)
-            .overlay(
+            .overlay {
                 HStack {
                     Spacer()
                     moveLeftButton
@@ -160,6 +160,6 @@ struct SliderStyleCursorBar<Extension: ApplicationSpecificKeyboardViewExtension>
                     moveRightButton
                     Spacer()
                 }
-            )
+            }
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -28,17 +28,15 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
         ZStack { [unowned variableStates] in
             theme.backgroundColor.color
                 .frame(maxWidth: .infinity)
-                .overlay(
-                    Group {
-                        if let image = theme.picture.image {
-                            image
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardScreenHeight(upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation))
-                                .clipped()
-                        }
+                .overlay {
+                    if let image = theme.picture.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardScreenHeight(upsideComponent: variableStates.upsideComponent, orientation: variableStates.keyboardOrientation))
+                            .clipped()
                     }
-                )
+                }
             VStack(spacing: 0) {
                 if let upsideComponent = variableStates.upsideComponent {
                     Group {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -247,9 +247,11 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                     .gesture(gesture)
                     .compositingGroup()
                     .shadow(color: theme.keyShadow?.color.color ?? .clear, radius: theme.keyShadow?.radius ?? 0, x: theme.keyShadow?.x ?? 0, y: theme.keyShadow?.y ?? 0)
-                    .overlay(label(width: size.width, color: nil))
+                    .overlay {
+                        label(width: size.width, color: nil)
+                    }
             }
-            .overlay(Group {
+            .overlay(alignment: .bottom) {
                 if self.suggest && self.model.needSuggestView {
                     let height = tabDesign.verticalSpacing + size.height
                     if self.pressState.needVariationsView && !self.model.variationsModel.variations.isEmpty {
@@ -263,11 +265,10 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                             direction: model.variationsModel.direction,
                             tabDesign: tabDesign
                         )
-                        .overlay(
+                        .overlay(alignment: self.model.variationsModel.direction.alignment) {
                             QwertyVariationsView<Extension>(model: self.model.variationsModel, selection: selection, tabDesign: tabDesign)
-                                .padding(.bottom, height),
-                            alignment: self.model.variationsModel.direction.alignment
-                        )
+                                .padding(.bottom, height)
+                        }
                         .compositingGroup()
                         .shadow(color: shadowColor, radius: 1, x: 0, y: 0)
                         .allowsHitTesting(false)
@@ -280,16 +281,16 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
                             borderWidth: keyBorderWidth,
                             tabDesign: tabDesign
                         )
-                        .overlay(
+                        .overlay {
                             label(width: size.width, color: suggestTextColor)
                                 .padding(.bottom, height)
-                        )
+                        }
                         .compositingGroup()
                         .shadow(color: shadowColor, radius: 1, x: 0, y: 0)
                         .allowsHitTesting(false)
                     }
                 }
-            }, alignment: .bottom)
+            }
         }
     }
 }

--- a/MainApp/Customize/CustomizeTabWalkthrough.swift
+++ b/MainApp/Customize/CustomizeTabWalkthrough.swift
@@ -52,11 +52,11 @@ struct CustomizeTabWalkthroughView: View {
                         let length = geometry.size.width / 4.8
                         Image(systemName: "gearshape.2.fill")
                             .font(.system(size: length / 2, weight: .bold, design: .default))
-                            .background(
+                            .background {
                                 RoundedRectangle(cornerRadius: length * 0.17)
                                     .fill(Color.systemGray5)
                                     .frame(width: length, height: length)
-                            )
+                            }
                         Text("azooKeyを拡張する").font(.largeTitle.bold())
                             .padding()
                         let imagesFont: Font = Font.system(size: length / 2.4, weight: .light, design: .default)

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -172,13 +172,13 @@ struct EditingTenkeyCustardView: CancelableEditor {
                             } label: {
                                 view.disabled(true)
                                     .opacity(0)
-                                    .overlay(
+                                    .overlay {
                                         Rectangle().stroke(style: .init(lineWidth: 2, dash: [5]))
-                                    )
-                                    .overlay(
+                                    }
+                                    .overlay {
                                         Image(systemName: "plus.circle")
                                             .foregroundStyle(.accentColor)
-                                    )
+                                    }
                             }
                         }
                     } else {

--- a/MainApp/General/LargeButtonStyle.swift
+++ b/MainApp/General/LargeButtonStyle.swift
@@ -19,10 +19,10 @@ struct LargeButtonStyle: ButtonStyle {
             .font(.body.bold())
             .padding()
             .frame(maxWidth: .infinity)
-            .background(
+            .background {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(backgroundColor)
-            )
+            }
             .opacity(configuration.isPressed ? 0.8 : 1)
     }
 }

--- a/MainApp/Setting/CustomKeys/FlickCustomKeys/CustomKeySettingFlickKeyView.swift
+++ b/MainApp/Setting/CustomKeys/FlickCustomKeys/CustomKeySettingFlickKeyView.swift
@@ -38,7 +38,9 @@ struct CustomKeySettingFlickKeyView<Label: View>: View {
     var body: some View {
         RoundedRectangle(cornerRadius: 10)
             .stroke(strokeColor)
-            .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
+            .background {
+                RoundedRectangle(cornerRadius: 10).fill(Color.background)
+            }
             .compositingGroup()
             .focus(.accentColor, focused: focused)
             .overlay {

--- a/MainApp/Setting/CustomKeys/FlickCustomKeys/CustomKeySettingFlickKeyView.swift
+++ b/MainApp/Setting/CustomKeys/FlickCustomKeys/CustomKeySettingFlickKeyView.swift
@@ -41,7 +41,9 @@ struct CustomKeySettingFlickKeyView<Label: View>: View {
             .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
             .compositingGroup()
             .focus(.accentColor, focused: focused)
-            .overlay(label())
+            .overlay {
+                label()
+            }
             .onTapGesture {
                 self.selectedPosition = position
             }

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
@@ -168,7 +168,9 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                         .compositingGroup()
                         .focus(.accentColor, focused: isSelected && selection.longpressSelectIndex == -1)
                         .focus(.systemGray, focused: isSelected && selection.longpressSelectIndex != -1)
-                        .overlay(Text(item.name))
+                        .overlay {
+                            Text(item.name)
+                        }
                 }
 
                 if setting.value.keys.indices ~= selection.selectIndex {
@@ -182,7 +184,9 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                             .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
                             .compositingGroup()
                             .focus(.accentColor, focused: isSelected)
-                            .overlay(Text(item.name))
+                            .overlay {
+                                Text(item.name)
+                            }
                     }
                 }
                 Spacer()

--- a/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
+++ b/MainApp/Setting/CustomKeys/QwertyCustomKeys/QwertyCustomKeysItemView.swift
@@ -164,7 +164,9 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                     }()
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(strokeColor)
-                        .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
+                        .background {
+                            RoundedRectangle(cornerRadius: 10).fill(Color.background)
+                        }
                         .compositingGroup()
                         .focus(.accentColor, focused: isSelected && selection.longpressSelectIndex == -1)
                         .focus(.systemGray, focused: isSelected && selection.longpressSelectIndex != -1)
@@ -181,7 +183,9 @@ struct QwertyCustomKeysSettingView<SettingKey: QwertyCustomKeyKeyboardSetting>: 
                     DraggableView(items: $setting.value.keys[selection.selectIndex].longpresses, selection: $selection.longpressSelectIndex, enabled: selection.longpressEnabled && editState.allowDrag, width: variationWidth, height: keySize.height, padding: padding) {item, isSelected in
                         RoundedRectangle(cornerRadius: 10)
                             .stroke(isSelected ? Color.accentColor : .primary)
-                            .background(RoundedRectangle(cornerRadius: 10).fill(Color.background))
+                            .background {
+                                RoundedRectangle(cornerRadius: 10).fill(Color.background)
+                            }
                             .compositingGroup()
                             .focus(.accentColor, focused: isSelected)
                             .overlay {

--- a/MainApp/Setting/FontSizeSetting/FontSizeSettingItemView.swift
+++ b/MainApp/Setting/FontSizeSetting/FontSizeSettingItemView.swift
@@ -98,6 +98,8 @@ private struct KeyView: View {
         RoundedRectangle(cornerRadius: 5)
             .stroke()
             .frame(width: size.width, height: size.height)
-            .overlay(Text(verbatim: "あ").font(.system(size: fontSize)))
+            .overlay {
+                Text(verbatim: "あ").font(.system(size: fontSize))
+            }
     }
 }

--- a/MainApp/Theme/ThemeShareView.swift
+++ b/MainApp/Theme/ThemeShareView.swift
@@ -155,7 +155,9 @@ private struct ShareButtonStyle: ButtonStyle {
             .font(.body.bold())
             .foregroundStyle(.white)
             .padding()
-            .background(RoundedRectangle(cornerRadius: 3).foregroundStyle(.blue))
+            .background {
+                RoundedRectangle(cornerRadius: 3).foregroundStyle(.blue)
+            }
             .padding()
     }
 }

--- a/MainApp/Theme/ThemeTab.swift
+++ b/MainApp/Theme/ThemeTab.swift
@@ -39,11 +39,11 @@ struct ThemeTabView: View {
         Circle()
             .fill(color)
             .frame(width: width, height: width)
-            .overlay(
+            .overlay {
                 Image(systemName: systemName)
                     .font(Font.system(size: width / 2).weight(.bold))
                     .foregroundStyle(.white)
-            )
+            }
     }
 
     private var tab: KeyboardTab.ExistentialTab {


### PR DESCRIPTION
Resolve #247 
