### PR TITLE
feat: OSネイティブライクなテーマを実装し、これをアプリのデフォルトに変更

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/AzooKeySpecificTheme.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/AzooKeySpecificTheme.swift
@@ -19,21 +19,24 @@ public enum AzooKeySpecificTheme: ApplicationSpecificTheme {
         case qwertyHighlightedKeyColor
         case specialKeyColor
         case backgroundColor
+        case nativeSpecialKeyColor
 
         public var color: Color {
             switch self {
             case .backgroundColor:
-                return Design.colors.backGroundColor
+                Design.colors.backGroundColor
             case .normalKeyColor:
-                return Design.colors.normalKeyColor(layout: .flick)
+                Design.colors.normalKeyColor(layout: .flick)
             case .qwertyNormalKeyColor:
-                return Design.colors.normalKeyColor(layout: .qwerty)
+                Design.colors.normalKeyColor(layout: .qwerty)
             case .specialKeyColor:
-                return Design.colors.specialKeyColor
+                Design.colors.specialKeyColor
             case .highlightedKeyColor:
-                return Design.colors.highlightedKeyColor(layout: .flick)
+                Design.colors.highlightedKeyColor(layout: .flick)
             case .qwertyHighlightedKeyColor:
-                return Design.colors.highlightedKeyColor(layout: .qwerty)
+                Design.colors.highlightedKeyColor(layout: .qwerty)
+            case .nativeSpecialKeyColor:
+                Design.colors.nativeSpecialKeyColor
             }
         }
     }
@@ -62,6 +65,25 @@ public extension AzooKeyTheme {
 }
 
 extension AzooKeySpecificTheme: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable {
+    public static func native(layout: KeyboardLayout) -> AzooKeyTheme {
+        .init(
+            backgroundColor: .dynamic(.clear),
+            picture: .none,
+            textColor: .dynamic(.primary),
+            textFont: .regular,
+            resultTextColor: .dynamic(.primary),
+            resultBackgroundColor: .dynamic(.clear),
+            borderColor: .dynamic(.clear),
+            borderWidth: 1,
+            normalKeyFillColor: .color(.white, blendMode: .softLight),
+            specialKeyFillColor: .system(.nativeSpecialKeyColor, blendMode: .softLight),
+            pushedKeyFillColor: .color(.systemGray4, blendMode: .softLight),
+            suggestKeyFillColor: nil,
+            suggestLabelTextColor: .dynamic(.black),
+            keyShadow: .init(color: .color(.black), radius: 0.5, x: 0, y: 0.75)
+        )
+    }
+
     public static func `default`(layout: KeyboardLayout) -> AzooKeyTheme {
         .init(
             backgroundColor: .system(.backgroundColor),

--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/ThemeManager.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/ThemeManager.swift
@@ -10,8 +10,11 @@ import Foundation
 import KeyboardThemes
 import SwiftUtils
 import UIKit
+import SwiftUICore
 
 struct ThemeIndices: Codable, Equatable {
+    static var defaultThemeIndex: Int { 0 }
+    static var classicDefaultThemeIndex: Int { -1 }
     var currentIndices: [Int] = [0]
     var selectedIndex: Int = 0
     var selectedIndex_dark: Int = 0
@@ -88,8 +91,23 @@ public struct ThemeIndexManager: Equatable {
         }
     }
 
+    public func themeTitle(at index: Int) -> LocalizedStringKey? {
+        switch index {
+        case ThemeIndices.classicDefaultThemeIndex:
+            "Classic"
+        case ThemeIndices.defaultThemeIndex:
+            "Default"
+        default:
+            nil
+        }
+    }
+
     public func theme(at index: Int) throws -> AzooKeyTheme {
-        if index == 0 {
+        // 特殊ケース
+        if index == ThemeIndices.defaultThemeIndex {
+            return AzooKeySpecificTheme.native(layout: .flick)
+        }
+        if index == ThemeIndices.classicDefaultThemeIndex {
             return AzooKeySpecificTheme.default(layout: .flick)
         }
         let themeFileURL = Self.fileURL(name: "themes/theme_\(index).theme")
@@ -177,7 +195,9 @@ public struct ThemeIndexManager: Equatable {
     }
 
     public var indices: [Int] {
-        index.currentIndices
+        let indices = index.currentIndices.filter{$0 > 0}.sorted()
+        // 負のindexについてはシステム側で並べる
+        return [ThemeIndices.defaultThemeIndex, ThemeIndices.classicDefaultThemeIndex] + indices
     }
 
     public var selectedIndex: Int {
@@ -189,7 +209,7 @@ public struct ThemeIndexManager: Equatable {
     }
 
     var nextIndex: Int {
-        (index.currentIndices.last ?? 0) + 1
+        (index.currentIndices.max() ?? 0) + 1
     }
 
 }

--- a/AzooKeyCore/Sources/KeyboardThemes/ApplicationSpecificTheme.swift
+++ b/AzooKeyCore/Sources/KeyboardThemes/ApplicationSpecificTheme.swift
@@ -13,5 +13,5 @@ public protocol ApplicationSpecificTheme {
 }
 
 public protocol ApplicationSpecificColor: Codable, Equatable, Sendable {
-    var color: SwiftUI.Color { get }
+    var color: Color { get }
 }

--- a/AzooKeyCore/Sources/KeyboardThemes/ThemeData.swift
+++ b/AzooKeyCore/Sources/KeyboardThemes/ThemeData.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import SwiftUIUtils
 
 public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable, Equatable, Sendable {
     public typealias ColorData = ThemeColor<ApplicationExtension.ApplicationColor>
@@ -82,6 +83,28 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
         /// エントリがない場合はデフォルトで黒にする
         self.suggestLabelTextColor = (try? container.decode(ColorData?.self, forKey: .suggestLabelTextColor)) ?? .color(Color(white: 0))
         self.keyShadow = try? container.decode(ThemeShadowData<ColorData>?.self, forKey: .keyShadow)
+    }
+
+    public var prominentBackgroundColor: Color {
+        ColorTools.hsv(self.resultBackgroundColor.color) { h, s, v, a in
+            Color(hue: h, saturation: s, brightness: min(1, 0.7 * v + 0.3), opacity: min(1, 0.8 * a + 0.2 ))
+        } ?? self.normalKeyFillColor.color
+    }
+
+    public var tabBarButtonBackgroundColor: Color {
+        if case .dynamic(.clear, .normal) = self.resultBackgroundColor {
+            .white
+        } else {
+            prominentBackgroundColor
+        }
+    }
+
+    public var tabBarButtonForegroundColor: Color {
+        if case .dynamic(.clear, .normal) = self.resultBackgroundColor {
+            Color(red: 0.5, green: 0.043, blue: 0.016)
+        } else {
+            self.resultTextColor.color
+        }
     }
 
 }

--- a/AzooKeyCore/Sources/KeyboardViews/ApplicationSpecificKeyboardViewExtension.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/ApplicationSpecificKeyboardViewExtension.swift
@@ -19,8 +19,10 @@ extension ApplicationSpecificKeyboardViewExtension {
 }
 
 public protocol ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable: ApplicationSpecificTheme {
-    /// レイアウトに依存したデフォルトテーマを返す
+    /// アプリケーションデフォルト
     static func `default`(layout: KeyboardLayout) -> ThemeData<Self>
+    /// ネイティブデザイン
+    static func native(layout: KeyboardLayout) -> ThemeData<Self>
 }
 
 public protocol ApplicationSpecificKeyboardViewMessageProvider {

--- a/AzooKeyCore/Sources/KeyboardViews/AzooKeyIcon.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/AzooKeyIcon.swift
@@ -45,14 +45,14 @@ public struct AzooKeyIcon: View {
         case .auto:
             switch colorScheme {
             case .light:
-                return .init(red: 0.398, green: 0.113, blue: 0.218)
+                .init(red: 0.398, green: 0.113, blue: 0.218)
             case .dark:
-                return .white
+                .white
             @unknown default:
-                return .init(red: 0.398, green: 0.113, blue: 0.218)
+                .init(red: 0.398, green: 0.113, blue: 0.218)
             }
         case let .color(color):
-            return color
+            color
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/Design.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Design.swift
@@ -327,6 +327,10 @@ public enum Design {
             Color("BackGroundColor_iOS15")
         }
 
+        public var nativeSpecialKeyColor: Color {
+            Color("NativeSpecialKeyColor")
+        }
+
         public var specialEnterKeyColor: Color {
             Color("OpenKeyColor")
         }
@@ -360,12 +364,6 @@ public enum Design {
             case .qwerty:
                 return Color("RomanHighlightedKeyColor")
             }
-        }
-
-        public func prominentBackgroundColor(_ theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-            ColorTools.hsv(theme.resultBackgroundColor.color) { h, s, v, a in
-                Color(hue: h, saturation: s, brightness: min(1, 0.7 * v + 0.3), opacity: min(1, 0.8 * a + 0.2 ))
-            } ?? theme.normalKeyFillColor.color
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/InKeyboardTextInput/InKeyboardSearchBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/InKeyboardTextInput/InKeyboardSearchBar.swift
@@ -102,7 +102,7 @@ private struct SearchBarWrapper<Extension: ApplicationSpecificKeyboardViewExtens
         view.barStyle = .default
         view.searchBarStyle = .minimal
         if let theme = configuration.theme {
-            view.searchTextField.backgroundColor = UIColor(Design.colors.prominentBackgroundColor(theme))
+            view.searchTextField.backgroundColor = UIColor(theme.prominentBackgroundColor)
         }
 
         view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -84,7 +84,7 @@ fileprivate extension CustardInterface {
 }
 
 fileprivate extension CustardKeyDesign.ColorType {
-    var FlickKeyBackgroundStyle: FlickKeyBackgroundStyle {
+    var flickKeyBackgroundStyle: FlickKeyBackgroundStyle {
         switch self {
         case .normal:
             return .normal
@@ -168,7 +168,7 @@ extension CustardInterfaceKey {
                 longPressActions: value.longpress_actions.longpressActionType,
                 flickKeys: flickKeyModels,
                 needSuggestView: value.longpress_actions == .none && !value.variations.isEmpty,
-                keycolorType: value.design.color.FlickKeyBackgroundStyle
+                keycolorType: value.design.color.flickKeyBackgroundStyle
             )
         }
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -84,7 +84,7 @@ fileprivate extension CustardInterface {
 }
 
 fileprivate extension CustardKeyDesign.ColorType {
-    var flickKeyColorType: FlickKeyColorType {
+    var FlickKeyBackgroundStyle: FlickKeyBackgroundStyle {
         switch self {
         case .normal:
             return .normal
@@ -97,7 +97,7 @@ fileprivate extension CustardKeyDesign.ColorType {
         }
     }
 
-    var qwertyKeyColorType: QwertyUnpressedKeyColorType {
+    var qwertyKeyColorType: QwertyUnpressedKeyBackground {
         switch self {
         case .normal:
             return .normal
@@ -168,7 +168,7 @@ extension CustardInterfaceKey {
                 longPressActions: value.longpress_actions.longpressActionType,
                 flickKeys: flickKeyModels,
                 needSuggestView: value.longpress_actions == .none && !value.variations.isEmpty,
-                keycolorType: value.design.color.flickKeyColorType
+                keycolorType: value.design.color.FlickKeyBackgroundStyle
             )
         }
     }
@@ -189,7 +189,7 @@ extension CustardInterfaceKey {
             case .changeKeyboard:
                 let changeKeyboardKeySize: QwertyKeySizeType = .normal(of: 1, for: 1)
                 return if let second = Extension.SettingProvider.preferredLanguage.second {
-                    QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyColorType: .special) { states in
+                    QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyBackground: .special) { states in
                         if SemiStaticStates.shared.needsInputModeSwitchKey {
                             return QwertyChangeKeyboardKeyModel(keySizeType: changeKeyboardKeySize)
                         } else {
@@ -211,7 +211,7 @@ extension CustardInterfaceKey {
                         }
                     }
                 } else {
-                    QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyColorType: .special) { states in
+                    QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyBackground: .special) { states in
                         if SemiStaticStates.shared.needsInputModeSwitchKey {
                             // 地球儀キーが必要な場合
                             QwertyChangeKeyboardKeyModel(keySizeType: changeKeyboardKeySize)
@@ -448,11 +448,11 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
                             .frame(width: info.contentSize.width, height: info.contentSize.height)
                             .contentShape(Rectangle())
                             .position(x: info.position.x, y: info.position.y)
-                            .blur(radius: needBlur ? 0.75 : 0)
+                            .opacity (needBlur ? 0.75 : 1.0)
                     }
                 }
                 .zIndex(columnSuggestStates.isEmpty ? 0 : 1)
-                .blur(radius: needColumnWideBlur ? 0.75 : 0)
+                .opacity(needColumnWideBlur ? 0.75 : 1.0)
             }
             .frame(width: tabDesign.keysWidth, height: tabDesign.keysHeight)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -448,7 +448,7 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
                             .frame(width: info.contentSize.width, height: info.contentSize.height)
                             .contentShape(Rectangle())
                             .position(x: info.position.x, y: info.position.y)
-                            .opacity (needBlur ? 0.75 : 1.0)
+                            .opacity(needBlur ? 0.75 : 1.0)
                     }
                 }
                 .zIndex(columnSuggestStates.isEmpty ? 0 : 1)

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyModel.swift
@@ -10,6 +10,14 @@ import Foundation
 import KeyboardThemes
 import SwiftUI
 
+public typealias SimpleKeyBackgroundStyleValue = (color: Color, blendMode: BlendMode)
+
+extension ThemeColor {
+    var simpleKeyBackgroundStyle: SimpleKeyBackgroundStyleValue {
+        (self.color, self.blendMode)
+    }
+}
+
 enum SimpleUnpressedKeyColorType: UInt8 {
     case normal
     case special
@@ -17,29 +25,31 @@ enum SimpleUnpressedKeyColorType: UInt8 {
     case selected
     case unimportant
 
-    @MainActor func color<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color {
+    @MainActor func color<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> SimpleKeyBackgroundStyleValue {
         switch self {
         case .normal:
-            return theme.normalKeyFillColor.color
+            theme.normalKeyFillColor.simpleKeyBackgroundStyle
         case .special:
-            return theme.specialKeyFillColor.color
+            theme.specialKeyFillColor.simpleKeyBackgroundStyle
         case .selected:
-            return theme.pushedKeyFillColor.color
+            theme.pushedKeyFillColor.simpleKeyBackgroundStyle
         case .unimportant:
-            return Color(white: 0, opacity: 0.001)
+            (Color(white: 0, opacity: 0.001), .normal)
         case .enter:
             switch states.enterKeyState {
             case .complete:
-                return theme.specialKeyFillColor.color
+                theme.specialKeyFillColor.simpleKeyBackgroundStyle
             case let .return(type):
                 switch type {
                 case .default:
-                    return theme.specialKeyFillColor.color
+                    theme.specialKeyFillColor.simpleKeyBackgroundStyle
                 default:
                     if theme == ThemeExtension.default(layout: states.tabManager.existentialTab().layout) {
-                        return Design.colors.specialEnterKeyColor
+                        (Design.colors.specialEnterKeyColor, .normal)
+                    } else if theme == ThemeExtension.default(layout: states.tabManager.existentialTab().layout) {
+                        (.accentColor, .normal)
                     } else {
-                        return theme.specialKeyFillColor.color
+                        theme.specialKeyFillColor.simpleKeyBackgroundStyle
                     }
                 }
             }
@@ -55,15 +65,15 @@ protocol SimpleKeyModelProtocol<Extension> {
     @MainActor func longPressActions(variableStates: VariableStates) -> LongpressActionType
     @MainActor func feedback(variableStates: VariableStates)
     @MainActor func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension>
-    @MainActor func backGroundColorWhenPressed(theme: Extension.Theme) -> Color
+    @MainActor func backgroundStyleWhenPressed(theme: Extension.Theme) -> SimpleKeyBackgroundStyleValue
     /// `pressActions`とは別に、押された際に発火する操作
     /// - note: タブ固有の事情で実行しなければならないような処理に利用すること
     @MainActor func additionalOnPress(variableStates: VariableStates)
 }
 
 extension SimpleKeyModelProtocol {
-    func backGroundColorWhenPressed(theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-        theme.pushedKeyFillColor.color
+    func backgroundStyleWhenPressed(theme: ThemeData<some ApplicationSpecificTheme>) -> SimpleKeyBackgroundStyleValue {
+        theme.pushedKeyFillColor.simpleKeyBackgroundStyle
     }
 
     func additionalOnPress(variableStates: VariableStates) {}
@@ -163,8 +173,8 @@ struct SimpleNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExt
             KeyboardFeedback<Extension>.tabOrOtherKey()
         }
     }
-    func backGroundColorWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color {
-        theme.specialKeyFillColor.color
+    func backgroundStyleWhenPressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> SimpleKeyBackgroundStyleValue {
+        theme.specialKeyFillColor.simpleKeyBackgroundStyle
     }
 }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -41,13 +41,16 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
     private var longpressDuration: TimeInterval {
         0.4
     }
+    private var keyBackground: SimpleKeyBackgroundStyleValue {
+        isPressed ? model.backgroundStyleWhenPressed(theme: theme) : model.unpressedKeyColorType.color(states: variableStates, theme: theme)
+    }
 
     public var body: some View {
         label(width: keyViewWidth)
             .background {
                 RoundedRectangle(cornerRadius: 6)
                     .strokeAndFill(
-                        fillContent: isPressed ? model.backGroundColorWhenPressed(theme: theme) : model.unpressedKeyColorType.color(states: variableStates, theme: theme),
+                        fillContent: keyBackground.color.blendMode(keyBackground.blendMode),
                         strokeContent: theme.borderColor.color,
                         lineWidth: theme.borderWidth
                     )

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickAaKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickAaKeyModel.swift
@@ -40,11 +40,11 @@ struct FlickAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Fli
         }
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    @MainActor func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         if states.boolStates.isCapsLocked {
-            return KeyLabel(.image("capslock.fill"), width: width)
+            KeyLabel(.image("capslock.fill"), width: width)
         } else {
-            return KeyLabel(.text("a/A"), width: width)
+            KeyLabel(.text("a/A"), width: width)
         }
     }
 
@@ -52,11 +52,11 @@ struct FlickAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Fli
         KeyboardFeedback<Extension>.tabOrOtherKey()
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
+    func backgroundStyleWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
         if states.boolStates.isCapsLocked {
-            return theme.specialKeyFillColor.color
+            theme.specialKeyFillColor.flickKeyBackgroundStyle
         } else {
-            return theme.normalKeyFillColor.color
+            theme.normalKeyFillColor.flickKeyBackgroundStyle
         }
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickChangeKeyboardKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickChangeKeyboardKeyModel.swift
@@ -45,7 +45,7 @@ struct FlickChangeKeyboardModel<Extension: ApplicationSpecificKeyboardViewExtens
         return [:]
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         switch SemiStaticStates.shared.needsInputModeSwitchKey {
         case true:
             return KeyLabel(.changeKeyboard, width: width)
@@ -54,8 +54,8 @@ struct FlickChangeKeyboardModel<Extension: ApplicationSpecificKeyboardViewExtens
         }
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-        theme.specialKeyFillColor.color
+    func backgroundStyleWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
+        theme.specialKeyFillColor.flickKeyBackgroundStyle
     }
 
     func feedback(variableStates: VariableStates) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickEnterKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickEnterKeyModel.swift
@@ -30,24 +30,46 @@ struct FlickEnterKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: 
         [:]
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
-        let text = Design.language.getEnterKeyText(states.enterKeyState)
-        return KeyLabel(.text(text), width: width)
-    }
-
-    func backGroundColorWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color {
+    func specialTextColor<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color? {
         switch states.enterKeyState {
         case .complete:
-            return theme.specialKeyFillColor.color
+            nil
         case let .return(type):
             switch type {
             case .default:
-                return theme.specialKeyFillColor.color
+                nil
+            default:
+                if theme == ThemeExtension.native(layout: .flick) {
+                    .white
+                } else {
+                    nil
+                }
+            }
+        }
+
+    }
+
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
+        let text = Design.language.getEnterKeyText(states.enterKeyState)
+
+        return KeyLabel(.text(text), width: width, textColor: specialTextColor(states: states, theme: theme))
+    }
+
+    func backgroundStyleWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> FlickKeyBackgroundStyleValue {
+        switch states.enterKeyState {
+        case .complete:
+            theme.specialKeyFillColor.flickKeyBackgroundStyle
+        case let .return(type):
+            switch type {
+            case .default:
+                theme.specialKeyFillColor.flickKeyBackgroundStyle
             default:
                 if theme == ThemeExtension.default(layout: .flick) {
-                    return Design.colors.specialEnterKeyColor
+                    (Design.colors.specialEnterKeyColor, .normal)
+                } else if theme == ThemeExtension.native(layout: .flick) {
+                    (.accentColor, .normal)
                 } else {
-                    return theme.specialKeyFillColor.color
+                    theme.specialKeyFillColor.flickKeyBackgroundStyle
                 }
             }
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKanaSymbolsKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKanaSymbolsKeyModel.swift
@@ -9,6 +9,7 @@
 import CustardKit
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct FlickKanaSymbolsKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: FlickKeyModelProtocol {
     let needSuggestView: Bool = true
@@ -33,7 +34,7 @@ struct FlickKanaSymbolsKeyModel<Extension: ApplicationSpecificKeyboardViewExtens
 
     private init() {}
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModel.swift
@@ -26,9 +26,9 @@ struct FlickKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Flick
     let labelType: KeyLabelType
     private let pressActions: [ActionType]
     let longPressActions: LongpressActionType
-    private let keycolorType: FlickKeyColorType
+    private let keycolorType: FlickKeyBackgroundStyle
 
-    init(labelType: KeyLabelType, pressActions: [ActionType], longPressActions: LongpressActionType = .none, flickKeys: [FlickDirection: FlickedKeyModel], needSuggestView: Bool = true, keycolorType: FlickKeyColorType = .normal) {
+    init(labelType: KeyLabelType, pressActions: [ActionType], longPressActions: LongpressActionType = .none, flickKeys: [FlickDirection: FlickedKeyModel], needSuggestView: Bool = true, keycolorType: FlickKeyBackgroundStyle = .normal) {
         self.labelType = labelType
         self.pressActions = pressActions
         self.longPressActions = longPressActions
@@ -37,8 +37,8 @@ struct FlickKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Flick
         self.keycolorType = keycolorType
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-        keycolorType.color(theme: theme)
+    func backgroundStyleWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
+        keycolorType.backgroundStyle(theme: theme)
     }
 
     func pressActions(variableStates: VariableStates) -> [ActionType] {
@@ -53,7 +53,7 @@ struct FlickKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Flick
         self.flickKeys
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModelProtocol.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyModelProtocol.swift
@@ -11,22 +11,30 @@ import Foundation
 import KeyboardThemes
 import SwiftUI
 
-enum FlickKeyColorType {
+public typealias FlickKeyBackgroundStyleValue = (color: Color, blendMode: BlendMode)
+
+extension ThemeColor {
+    var flickKeyBackgroundStyle: FlickKeyBackgroundStyleValue {
+        (self.color, self.blendMode)
+    }
+}
+
+enum FlickKeyBackgroundStyle {
     case normal
     case tabkey
     case selected
     case unimportant
 
-    func color(theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
+    func backgroundStyle(theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
         switch self {
         case .normal:
-            return theme.normalKeyFillColor.color
+            return (theme.normalKeyFillColor.color, theme.normalKeyFillColor.blendMode)
         case .tabkey:
-            return theme.specialKeyFillColor.color
+            return (theme.specialKeyFillColor.color, theme.specialKeyFillColor.blendMode)
         case .selected:
-            return theme.pushedKeyFillColor.color
+            return (theme.pushedKeyFillColor.color, theme.pushedKeyFillColor.blendMode)
         case .unimportant:
-            return Color(white: 0, opacity: 0.001)
+            return (Color(white: 0, opacity: 0.001), .normal)
         }
     }
 }
@@ -38,13 +46,13 @@ public protocol FlickKeyModelProtocol<Extension> {
 
     @MainActor func pressActions(variableStates: VariableStates) -> [ActionType]
     @MainActor func longPressActions(variableStates: VariableStates) -> LongpressActionType
-    @MainActor func backGroundColorWhenPressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(theme: ThemeData<ThemeExtension>) -> Color
-    @MainActor func backGroundColorWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color
+    @MainActor func backgroundStyleWhenPressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(theme: ThemeData<ThemeExtension>) -> FlickKeyBackgroundStyleValue
+    @MainActor func backgroundStyleWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> FlickKeyBackgroundStyleValue
 
     @MainActor func flickKeys(variableStates: VariableStates) -> [FlickDirection: FlickedKeyModel]
     @MainActor func isFlickAble(to direction: FlickDirection, variableStates: VariableStates) -> Bool
 
-    @MainActor func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension>
+    @MainActor func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension>
 
     @MainActor func flickSensitivity(to direction: FlickDirection) -> CGFloat
     @MainActor func feedback(variableStates: VariableStates)
@@ -56,12 +64,12 @@ extension FlickKeyModelProtocol {
         (flickKeys(variableStates: variableStates) as [FlickDirection: FlickedKeyModel]).keys.contains(direction)
     }
 
-    func backGroundColorWhenPressed(theme: ThemeData<some ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>) -> Color {
-        theme.pushedKeyFillColor.color
+    func backgroundStyleWhenPressed(theme: ThemeData<some ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>) -> FlickKeyBackgroundStyleValue {
+        (theme.pushedKeyFillColor.color, theme.pushedKeyFillColor.blendMode)
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-        theme.normalKeyFillColor.color
+    func backgroundStyleWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
+        (theme.normalKeyFillColor.color, theme.normalKeyFillColor.blendMode)
     }
 
     @MainActor func flickSensitivity(to direction: FlickDirection) -> CGFloat {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -66,7 +66,7 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
     }
 
     private func label(width: CGFloat) -> KeyLabel<Extension> {
-        self.model.label(width: width, states: variableStates)
+        self.model.label(width: width, theme: theme, states: variableStates)
     }
 
     /// 長押しとみなすまでの時間
@@ -222,11 +222,11 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
             }
     }
 
-    private var keyFillColor: Color {
+    private var keyBackgroundStyle: FlickKeyBackgroundStyleValue {
         if pressState.isActive() {
-            return model.backGroundColorWhenPressed(theme: theme)
+            return model.backgroundStyleWhenPressed(theme: theme)
         } else {
-            return model.backGroundColorWhenUnpressed(states: variableStates, theme: theme)
+            return model.backgroundStyleWhenUnpressed(states: variableStates, theme: theme)
         }
     }
 
@@ -234,14 +234,25 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
         theme.borderColor.color
     }
 
+    private var keyShadow: ShadowStyle {
+        .drop(
+            color: theme.keyShadow?.color.color ?? .clear,
+            radius: theme.keyShadow?.radius ?? 0.0,
+            x: theme.keyShadow?.x ?? 0,
+            y: theme.keyShadow?.y ?? 0
+        )
+    }
+
     public var body: some View {
         let keySize = (width: size.width, height: size.height)
         RoundedRectangle(cornerRadius: 6)
-            .strokeAndFill(fillContent: keyFillColor, strokeContent: keyBorderColor, lineWidth: theme.borderWidth)
+            .strokeAndFill(
+                fillContent: keyBackgroundStyle.color.shadow(keyShadow).blendMode(keyBackgroundStyle.blendMode),
+                strokeContent: keyBorderColor,
+                lineWidth: theme.borderWidth
+            )
             .frame(width: keySize.width, height: keySize.height)
             .gesture(gesture)
-            .compositingGroup()
-            .shadow(color: theme.keyShadow?.color.color ?? .clear, radius: theme.keyShadow?.radius ?? 0, x: theme.keyShadow?.x ?? 0, y: theme.keyShadow?.y ?? 0)
             .overlay {
                 self.label(width: keySize.width)
             }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKogakiKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKogakiKeyModel.swift
@@ -9,6 +9,7 @@
 import CustardKit
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct FlickKogakiKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: FlickKeyModelProtocol {
     let needSuggestView: Bool = true
@@ -35,7 +36,7 @@ struct FlickKogakiKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         .none
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickNextCandidateKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickNextCandidateKeyModel.swift
@@ -58,7 +58,7 @@ struct FlickNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExte
 
     private init() {}
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         if states.resultModel.results.isEmpty {
             KeyLabel(.text("空白"), width: width)
         } else {
@@ -73,7 +73,7 @@ struct FlickNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExte
             KeyboardFeedback<Extension>.tabOrOtherKey()
         }
     }
-    func backGroundColorWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color {
-        theme.specialKeyFillColor.color
+    func backgroundStyleWhenUnpressed<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> FlickKeyBackgroundStyleValue {
+        theme.specialKeyFillColor.flickKeyBackgroundStyle
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickSpaceKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickSpaceKeyModel.swift
@@ -43,12 +43,12 @@ struct FlickSpaceKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: 
         .init(start: [.setCursorBar(.toggle)])
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(.text("空白"), width: width)
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-        theme.specialKeyFillColor.color
+    func backgroundStyleWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
+        theme.specialKeyFillColor.flickKeyBackgroundStyle
     }
 
     func feedback(variableStates: VariableStates) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickTabKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickTabKeyModel.swift
@@ -37,15 +37,16 @@ struct FlickTabKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Fl
         self.tab = tab
     }
 
-    func label(width: CGFloat, states: VariableStates) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates) -> KeyLabel<Extension> {
         KeyLabel(self.data.labelType, width: width)
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
+    func backgroundStyleWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> FlickKeyBackgroundStyleValue {
         if states.tabManager.isCurrentTab(tab: tab) {
-            return theme.pushedKeyFillColor.color
+            theme.pushedKeyFillColor.flickKeyBackgroundStyle
+        } else {
+            theme.specialKeyFillColor.flickKeyBackgroundStyle
         }
-        return theme.specialKeyFillColor.color
     }
 
     func feedback(variableStates: VariableStates) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/SuggestView/FlickSuggestView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/SuggestView/FlickSuggestView.swift
@@ -49,7 +49,7 @@ struct FlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtension>: Vi
             theme != Extension.ThemeExtension.default(layout: .flick) ? .white : .systemGray5
         }
         var shadowColor: Color {
-            if colorScheme == .dark || theme != Extension.ThemeExtension.default(layout: .flick) {
+            if colorScheme == .dark || (theme != Extension.ThemeExtension.default(layout: .flick) && theme != Extension.ThemeExtension.native(layout: .flick)) {
                 .clear
             } else {
                 .gray
@@ -167,7 +167,7 @@ struct FlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtension>: Vi
                         )
                         .zIndex(2)
                         .overlay {
-                            (self.model.label(width: size.width, states: variableStates))
+                            (self.model.label(width: size.width, theme: theme, states: variableStates))
                                 .textColor(.white)
                                 .textSize(.xlarge)
                         }
@@ -196,7 +196,7 @@ struct FlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtension>: Vi
                         .zIndex(1)
                     RoundedRectangle(cornerRadius: 5.0)
                         .strokeAndFill(
-                            fillContent: theme.specialKeyFillColor.color,
+                            fillContent: theme.specialKeyFillColor.color.blendMode(theme.specialKeyFillColor.blendMode),
                             strokeContent: theme.borderColor.color,
                             lineWidth: theme.borderWidth
                         )

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
@@ -95,11 +95,11 @@ struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: V
     }
 
     private var buttonBackgroundColor: Color {
-        Design.colors.prominentBackgroundColor(theme)
+        theme.tabBarButtonBackgroundColor
     }
 
     private var buttonLabelColor: Color {
-        theme.resultTextColor.color
+        theme.tabBarButtonForegroundColor
     }
 
     private var circleSize: CGFloat {

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardView.swift
@@ -26,7 +26,8 @@ public struct KeyboardView<Extension: ApplicationSpecificKeyboardViewExtension>:
 
     public var body: some View {
         ZStack { [unowned variableStates] in
-            theme.backgroundColor.color
+            Rectangle()
+                .foregroundStyle(theme.backgroundColor.color)
                 .frame(maxWidth: .infinity)
                 .overlay {
                     if let image = theme.picture.image {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift
@@ -7,6 +7,7 @@
 //
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct QwertyAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
     static var shared: Self { QwertyAaKeyModel() }
@@ -28,7 +29,7 @@ struct QwertyAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qw
         .init(start: [.setBoolState(VariableStates.BoolStates.isCapsLockedKey, .toggle)])
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if states.boolStates.isCapsLocked {
             return KeyLabel(.image("capslock.fill"), width: width, textColor: color)
         } else {
@@ -36,7 +37,7 @@ struct QwertyAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qw
         }
     }
 
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .special
 
     func feedback(variableStates: VariableStates) {
         KeyboardFeedback<Extension>.tabOrOtherKey()

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyChangeKeyboardKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyChangeKeyboardKeyModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import enum CustardKit.TabData
 import enum KanaKanjiConverterModule.KeyboardLanguage
+import KeyboardThemes
 
 struct QwertyChangeKeyboardKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
     func pressActions(variableStates: VariableStates) -> [ActionType] {
@@ -25,13 +26,13 @@ struct QwertyChangeKeyboardKeyModel<Extension: ApplicationSpecificKeyboardViewEx
     let needSuggestView: Bool = false
 
     let keySizeType: QwertyKeySizeType
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .special
 
     init(keySizeType: QwertyKeySizeType) {
         self.keySizeType = keySizeType
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         KeyLabel(.changeKeyboard, width: width, textColor: color)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyConditionalKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyConditionalKeyModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 import enum CustardKit.TabData
 import enum KanaKanjiConverterModule.KeyboardLanguage
+import KeyboardThemes
 
 struct QwertyConditionalKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
     var keySizeType: QwertyKeySizeType
@@ -17,7 +18,7 @@ struct QwertyConditionalKeyModel<Extension: ApplicationSpecificKeyboardViewExten
 
     var variationsModel: VariationsModel = .init([])
 
-    var unpressedKeyColorType: QwertyUnpressedKeyColorType
+    var unpressedKeyBackground: QwertyUnpressedKeyBackground
 
     /// 条件に基づいてモデルを返すclosure
     var key: (VariableStates) -> (any QwertyKeyModelProtocol<Extension>)
@@ -30,8 +31,8 @@ struct QwertyConditionalKeyModel<Extension: ApplicationSpecificKeyboardViewExten
         key(variableStates).longPressActions(variableStates: variableStates)
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
-        key(states).label(width: width, states: states, color: color)
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+        key(states).label(width: width, theme: theme, states: states, color: color)
     }
 
     func feedback(variableStates: VariableStates) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyEnterKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyEnterKeyModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct QwertyEnterKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
     let keySizeType: QwertyKeySizeType
@@ -34,12 +35,30 @@ struct QwertyEnterKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         .none
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
-        let text = Design.language.getEnterKeyText(states.enterKeyState)
-        return KeyLabel(.text(text), width: width, textSize: .small, textColor: color)
+    func specialTextColor<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(states: VariableStates, theme: ThemeData<ThemeExtension>) -> Color? {
+        switch states.enterKeyState {
+        case .complete:
+            nil
+        case let .return(type):
+            switch type {
+            case .default:
+                nil
+            default:
+                if theme == ThemeExtension.native(layout: .flick) {
+                    .white
+                } else {
+                    nil
+                }
+            }
+        }
     }
 
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .enter
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+        let text = Design.language.getEnterKeyText(states.enterKeyState)
+        return KeyLabel(.text(text), width: width, textSize: .small, textColor: color ?? specialTextColor(states: states, theme: theme))
+    }
+
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .enter
 
     func feedback(variableStates: VariableStates) {
         switch variableStates.enterKeyState {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyFunctionalKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyFunctionalKeyModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct QwertyFunctionalKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
     static var delete: Self { QwertyFunctionalKeyModel(labelType: .image("delete.left"), rowInfo: (normal: 7, functional: 2, space: 0, enter: 0), pressActions: [.delete(1)], longPressActions: .init(repeat: [.delete(1)])) }
@@ -20,7 +21,7 @@ struct QwertyFunctionalKeyModel<Extension: ApplicationSpecificKeyboardViewExtens
     let labelType: KeyLabelType
     let needSuggestView: Bool
     let keySizeType: QwertyKeySizeType
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .special
 
     init(labelType: KeyLabelType, rowInfo: (normal: Int, functional: Int, space: Int, enter: Int), pressActions: [ActionType], longPressActions: LongpressActionType = .none, needSuggestView: Bool = false) {
         self.labelType = labelType
@@ -38,7 +39,7 @@ struct QwertyFunctionalKeyModel<Extension: ApplicationSpecificKeyboardViewExtens
         self.longPressActions
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         KeyLabel(self.labelType, width: width, textColor: color)
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct QwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
 
@@ -19,19 +20,19 @@ struct QwertyKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qwer
     let variationsModel: VariationsModel
 
     let keySizeType: QwertyKeySizeType
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground
 
-    init(labelType: KeyLabelType, pressActions: [ActionType], longPressActions: LongpressActionType = .none, variationsModel: VariationsModel = VariationsModel([]), keyColorType: QwertyUnpressedKeyColorType = .normal, needSuggestView: Bool = true, for scale: (normalCount: Int, forCount: Int) = (1, 1)) {
+    init(labelType: KeyLabelType, pressActions: [ActionType], longPressActions: LongpressActionType = .none, variationsModel: VariationsModel = VariationsModel([]), keyColorType: QwertyUnpressedKeyBackground = .normal, needSuggestView: Bool = true, for scale: (normalCount: Int, forCount: Int) = (1, 1)) {
         self.labelType = labelType
         self.pressActions = pressActions
         self.longPressActions = longPressActions
         self.needSuggestView = needSuggestView
         self.variationsModel = variationsModel
         self.keySizeType = .normal(of: scale.normalCount, for: scale.forCount)
-        self.unpressedKeyColorType = keyColorType
+        self.unpressedKeyBackground = keyColorType
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if (states.boolStates.isCapsLocked || states.boolStates.isShifted), states.keyboardLanguage == .en_US, case let .text(text) = self.labelType {
             return KeyLabel(.text(text.uppercased()), width: width, textColor: color)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -195,11 +195,11 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
             })
     }
 
-    var keyFillColor: Color {
+    var keyFillColor: QwertyKeyBackgroundStyleValue {
         if self.pressState.isActive {
-            return self.model.backGroundColorWhenPressed(theme: theme)
+            self.model.backgroundStyleWhenPressed(theme: theme)
         } else {
-            return self.model.unpressedKeyColorType.color(states: variableStates, theme: theme)
+            self.model.unpressedKeyBackground.color(states: variableStates, theme: theme)
         }
     }
 
@@ -231,22 +231,33 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
     }
 
     private func label(width: CGFloat, color: Color?) -> some View {
-        self.model.label(width: width, states: variableStates, color: color)
+        self.model.label(width: width, theme: theme, states: variableStates, color: color)
+    }
+
+    private var keyShadow: ShadowStyle {
+        .drop(
+            color: theme.keyShadow?.color.color ?? .clear,
+            radius: theme.keyShadow?.radius ?? 0.0,
+            x: theme.keyShadow?.x ?? 0,
+            y: theme.keyShadow?.y ?? 0
+        )
     }
 
     var body: some View {
         ZStack(alignment: .bottom) {
             Group {
                 RoundedRectangle(cornerRadius: 6)
-                    .strokeAndFill(fillContent: keyFillColor, strokeContent: keyBorderColor, lineWidth: keyBorderWidth)
+                    .strokeAndFill(
+                        fillContent: keyFillColor.color.shadow(keyShadow).blendMode(keyFillColor.blendMode),
+                        strokeContent: keyBorderColor,
+                        lineWidth: keyBorderWidth
+                    )
                     .frame(width: size.width, height: size.height)
                     .contentShape(
                         Rectangle()
                             .size(CGSize(width: size.width + tabDesign.horizontalSpacing, height: size.height + tabDesign.verticalSpacing))
                     )
                     .gesture(gesture)
-                    .compositingGroup()
-                    .shadow(color: theme.keyShadow?.color.color ?? .clear, radius: theme.keyShadow?.radius ?? 0, x: theme.keyShadow?.x ?? 0, y: theme.keyShadow?.y ?? 0)
                     .overlay {
                         label(width: size.width, color: nil)
                     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyLanguageSwitchKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyLanguageSwitchKeyModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import SwiftUI
 import enum KanaKanjiConverterModule.KeyboardLanguage
+import KeyboardThemes
 
 // symbolタブ、123タブで表示される切り替えボタン
 struct QwertySwitchLanguageKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
@@ -48,14 +49,14 @@ struct QwertySwitchLanguageKeyModel<Extension: ApplicationSpecificKeyboardViewEx
     let needSuggestView: Bool = false
 
     let keySizeType: QwertyKeySizeType
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .special
 
     init(rowInfo: (normal: Int, functional: Int, space: Int, enter: Int), languages: (KeyboardLanguage, KeyboardLanguage)) {
         self.keySizeType = .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space)
         self.languages = languages
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         let current = currentTabLanguage(variableStates: states)
         return if languages.0 == current {
             KeyLabel(.selectable(languages.0.symbol, languages.1.symbol), width: width, textColor: color)

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyNextCandidateKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyNextCandidateKeyModel.swift
@@ -18,7 +18,7 @@ struct QwertyNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExt
 
     let variationsModel: VariationsModel = .init([])
 
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .normal
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .normal
 
     static var shared: Self { QwertyNextCandidateKeyModel<Extension>() }
 
@@ -38,7 +38,7 @@ struct QwertyNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExt
         }
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if states.resultModel.results.isEmpty {
             switch states.keyboardLanguage {
             case .el_GR:
@@ -53,8 +53,8 @@ struct QwertyNextCandidateKeyModel<Extension: ApplicationSpecificKeyboardViewExt
         }
     }
 
-    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> Color {
-        theme.specialKeyFillColor.color
+    func backGroundColorWhenUnpressed(states: VariableStates, theme: ThemeData<some ApplicationSpecificTheme>) -> QwertyKeyBackgroundStyleValue {
+        theme.specialKeyFillColor.qwertyKeyBackgroundStyle
     }
 
     func feedback(variableStates: VariableStates) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyShiftKeyModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import KeyboardThemes
 
 struct QwertyShiftKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
     init(keySizeType: QwertyKeySizeType = .normal(of: 1, for: 1)) {
@@ -41,7 +42,7 @@ struct QwertyShiftKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         }
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         if states.boolStates.isCapsLocked {
             return KeyLabel(.image("capslock.fill"), width: width, textColor: color)
         } else if states.boolStates.isShifted {
@@ -51,7 +52,7 @@ struct QwertyShiftKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>:
         }
     }
 
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .special
 
     func feedback(variableStates: VariableStates) {
         KeyboardFeedback<Extension>.tabOrOtherKey()

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySpaceKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySpaceKeyModel.swift
@@ -8,17 +8,18 @@
 
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 struct QwertySpaceKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
 
     let needSuggestView: Bool = false
     let variationsModel = VariationsModel([])
     let keySizeType: QwertyKeySizeType = .space
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .normal
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .normal
 
     init() {}
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         switch states.keyboardLanguage {
         case .el_GR:
             return KeyLabel(.text("διάστημα"), width: width, textSize: .small, textColor: color)

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySuggestView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertySuggestView.swift
@@ -88,14 +88,14 @@ struct QwertySuggestView {
         .scale(x: width / 109, y: (tabDesign.keyViewHeight * 2 + tabDesign.verticalSpacing) / 281, anchor: .top)
     }
 
-    @MainActor static func scaleToFrameSize(keyWidth: CGFloat, scale_y: CGFloat, color: Color, borderColor: Color, borderWidth: CGFloat, tabDesign: TabDependentDesign) -> some View {
+    @MainActor static func scaleToFrameSize(keyWidth: CGFloat, scale_y: CGFloat, color: some ShapeStyle, borderColor: some ShapeStyle, borderWidth: CGFloat, tabDesign: TabDependentDesign) -> some View {
         let height = (tabDesign.keyViewHeight * 2 + tabDesign.verticalSpacing) * scale_y
         return expandedPath(rdw: 0, ldw: 0, width: keyWidth, tabDesign: tabDesign)
             .strokeAndFill(fillContent: color, strokeContent: borderColor, lineWidth: borderWidth)
             .frame(width: keyWidth, height: height)
     }
 
-    @MainActor static func scaleToVariationsSize(keyWidth: CGFloat, scale_y: CGFloat, variationsCount: Int, color: Color, borderColor: Color, borderWidth: CGFloat, direction: VariationsViewDirection, tabDesign: TabDependentDesign) -> some View {
+    @MainActor static func scaleToVariationsSize(keyWidth: CGFloat, scale_y: CGFloat, variationsCount: Int, color: some ShapeStyle, borderColor: some ShapeStyle, borderWidth: CGFloat, direction: VariationsViewDirection, tabDesign: TabDependentDesign) -> some View {
         let keyViewSize = tabDesign.keyViewSize
         let height = (keyViewSize.height * 2 + tabDesign.verticalSpacing) * scale_y
         let dw = (keyViewSize.width * CGFloat(variationsCount - 1) + tabDesign.horizontalSpacing * CGFloat(variationsCount - 1)) * 109 / keyViewSize.width

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyTabKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyTabKeyModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftUI
+import KeyboardThemes
 
 // symbolタブ、123タブで表示される切り替えボタン
 struct QwertyTabKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: QwertyKeyModelProtocol {
@@ -35,13 +36,13 @@ struct QwertyTabKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Q
     let needSuggestView: Bool = false
 
     let keySizeType: QwertyKeySizeType
-    let unpressedKeyColorType: QwertyUnpressedKeyColorType = .special
+    let unpressedKeyBackground: QwertyUnpressedKeyBackground = .special
 
     init(rowInfo: (normal: Int, functional: Int, space: Int, enter: Int)) {
         self.keySizeType = .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space)
     }
 
-    func label(width: CGFloat, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
+    func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         switch SemiStaticStates.shared.needsInputModeSwitchKey {
         case true:
             switch states.keyboardLanguage {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/QwertyDataProvider.swift
@@ -32,7 +32,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
         let symbolsKey: any QwertyKeyModelProtocol<Extension> = QwertyFunctionalKeyModel(labelType: .text("#+="), rowInfo: rowInfo, pressActions: [.moveTab(.system(.qwerty_symbols))], longPressActions: .init(start: [.setTabBar(.toggle)]))
         let changeKeyboardKeySize: QwertyKeySizeType = .functional(normal: rowInfo.normal, functional: rowInfo.functional, enter: rowInfo.enter, space: rowInfo.space)
         let changeKeyboardKey: any QwertyKeyModelProtocol<Extension> = if let second = preferredLanguage.second {
-            QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyColorType: .special) { states in
+            QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyBackground: .special) { states in
                 if SemiStaticStates.shared.needsInputModeSwitchKey {
                     // 地球儀キーが必要な場合
                     return switch states.tabManager.existentialTab() {
@@ -74,7 +74,7 @@ struct QwertyDataProvider<Extension: ApplicationSpecificKeyboardViewExtension> {
                 }
             }
         } else {
-            QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyColorType: .special) { states in
+            QwertyConditionalKeyModel(keySizeType: changeKeyboardKeySize, needSuggestView: false, unpressedKeyBackground: .special) { states in
                 if SemiStaticStates.shared.needsInputModeSwitchKey {
                     // 地球儀キーが必要な場合
                     QwertyChangeKeyboardKeyModel(keySizeType: changeKeyboardKeySize)

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/ClipboardHistoryTab.swift
@@ -59,7 +59,7 @@ struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>:
 
     init() {}
     private var listRowBackgroundColor: Color {
-        Design.colors.prominentBackgroundColor(theme)
+        theme.prominentBackgroundColor
     }
 
     @ViewBuilder
@@ -139,7 +139,10 @@ struct ClipboardHistoryTab<Extension: ApplicationSpecificKeyboardViewExtension>:
 
             }
         }
-        .listRowBackground(listRowBackgroundColor)
+        .listRowBackground(
+            Rectangle()
+                .foregroundStyle(listRowBackgroundColor)
+        )
         .listRowInsets(EdgeInsets())
         .padding(.leading, 7)
         .padding(.trailing, 2)

--- a/AzooKeyCore/Sources/SwiftUIUtils/StrokeAndFill.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/StrokeAndFill.swift
@@ -10,10 +10,17 @@ import Foundation
 import SwiftUI
 
 public extension Shape {
+    @ViewBuilder
     func strokeAndFill(fillContent: some ShapeStyle, strokeContent: some ShapeStyle, lineWidth: CGFloat) -> some View {
-        ZStack {
-            self.fill(fillContent)
-            self.stroke(strokeContent, lineWidth: lineWidth)
+        if #available(iOS 17, *) {
+            self
+                .fill(fillContent)
+                .stroke(strokeContent, lineWidth: lineWidth)
+        } else {
+            ZStack {
+                self.fill(fillContent)
+                self.stroke(strokeContent, lineWidth: lineWidth)
+            }
         }
     }
 }

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -77,6 +77,12 @@ final class KeyboardViewController: UIInputViewController {
         }
     }
 
+    override func loadView() {
+        super.loadView()
+        // これをやることで背景が透け透けになり、OSネイティブに近い表示になる
+        self.view.backgroundColor = .clear
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         SemiStaticStates.shared.setup()
@@ -104,6 +110,9 @@ final class KeyboardViewController: UIInputViewController {
         host.setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
 
         host.view.translatesAutoresizingMaskIntoConstraints = false
+        // 背景をOSネイティブにするのに必要
+        host.view.backgroundColor = .clear
+
         self.addChild(host)
         self.view.addSubview(host.view)
         host.didMove(toParent: self)

--- a/MainApp/Theme/ThemeTab.swift
+++ b/MainApp/Theme/ThemeTab.swift
@@ -71,9 +71,27 @@ struct ThemeTabView: View {
                                     Color.black.opacity(0.3)
                                 }
                             }
+                            .background {
+                                Rectangle()
+                                    .foregroundStyle(.systemGray4)
+                            }
                             .onTapGesture {
                                 if manager.selectedIndex != index && manager.selectedIndexInDarkMode != index {
                                     self.manager.select(at: index)
+                                }
+                            }
+                            .overlay(alignment: .bottom) {
+                                if let title = manager.themeTitle(at: index) {
+                                    Text(title)
+                                        .bold()
+                                        .font(.caption)
+                                        .padding(8)
+                                        .background {
+                                            Capsule()
+                                                .foregroundStyle(.regularMaterial)
+                                                .shadow(radius: 1.5)
+                                        }
+                                        .padding(.bottom, 4)
                                 }
                             }
                         if manager.selectedIndex == manager.selectedIndexInDarkMode,
@@ -108,7 +126,7 @@ struct ThemeTabView: View {
                                 }
                             }
                         }
-                        if index != 0 {
+                        if index > 0 {
                             Button("編集", systemImage: "slider.horizontal.3") {
                                 self.editViewIndex = index
                                 self.path.append(.edit(index: index))
@@ -132,11 +150,11 @@ struct ThemeTabView: View {
                         self.editViewIndex = index
                         self.path.append(.edit(index: index))
                     }
-                    .disabled(index == 0)
+                    .disabled(index <= 0)
                     Button("削除する", systemImage: "trash", role: .destructive) {
                         manager.remove(index: index)
                     }
-                    .disabled(index == 0)
+                    .disabled(index <= 0)
                 }
             }
         }

--- a/Resources/Designs.xcassets/NativeSpecialKeyColor.colorset/Contents.json
+++ b/Resources/Designs.xcassets/NativeSpecialKeyColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.700",
+          "green" : "0.700",
+          "red" : "0.700"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
これまでazooKey v1.0当時から使い続けてきた単色のテーマを使い続けてきた。しかし、単色テーマではOSが設定する背景との一貫性が壊れてしまう。特に最近登場したApple Intelligenceでは虹色のグラデーションがキーボード背景にまで及ぶが、azooKeyではこれに対応できていない。

そこで、OSネイティブに近いデザインを採用した新しいテーマを設計し、これをデフォルト挙動とした。従来のテーマは「クラシック」として利用できるようにしている。