### PR TITLE
feat: 当たり判定が壊れていた問題を修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardThemes/ThemeColor.swift
+++ b/AzooKeyCore/Sources/KeyboardThemes/ThemeColor.swift
@@ -50,20 +50,21 @@ public enum ThemeColor<SystemColor: ApplicationSpecificColor>: Sendable {
 
         var color: Color {
             switch self {
-            case .accentColor: return .accentColor
-            case .black: return .black
-            case .blue: return .blue
-            case .clear: return .clear
-            case .gray: return .gray
-            case .green: return .green
-            case .orange: return .orange
-            case .pink: return .pink
-            case .primary: return .primary
-            case .purple: return .purple
-            case .red: return .red
-            case .secondary: return .secondary
-            case .yellow: return .yellow
-            case .white: return .white
+            case .accentColor: .accentColor
+            case .black: .black
+            case .blue: .blue
+            // デフォルトの`.clear`は当たり判定が失われるため、透明に近いが透明ではないビューで置き換える
+            case .clear: Color(white: 0, opacity: 0.001)
+            case .gray: .gray
+            case .green: .green
+            case .orange: .orange
+            case .pink: .pink
+            case .primary: .primary
+            case .purple: .purple
+            case .red: .red
+            case .secondary: .secondary
+            case .yellow: .yellow
+            case .white: .white
             }
         }
     }


### PR DESCRIPTION
This pull request modifies the `ThemeColor` enum in `ThemeColor.swift` to improve how colors are handled, particularly addressing an issue with the `.clear` color. The most important change ensures that `.clear` now uses a nearly transparent color to maintain interaction hit testing.

### Improvements to color handling:

* [`ThemeColor.swift`](diffhunk://#diff-ceee9c3a55ce35622be38069a2eb1a04dae16cebf0fed3ae7b3377946a5ece4cL53-R67): Updated the `.clear` case to use `Color(white: 0, opacity: 0.001)` instead of the default `.clear`, preventing loss of touch interaction while maintaining near-transparency. This change ensures better user experience when `.clear` is used in interactive views.