### PR TITLE
fix: textformat.altはロケール依存で期待した動作をしていないので、テキストに置き換え

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift
@@ -33,7 +33,7 @@ struct QwertyAaKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Qw
         if states.boolStates.isCapsLocked {
             return KeyLabel(.image("capslock.fill"), width: width, textColor: color)
         } else {
-            return KeyLabel(.image("textformat.alt"), width: width, textColor: color)
+            return KeyLabel(.text("Aa"), width: width, textColor: color)
         }
     }
 


### PR DESCRIPTION
This pull request includes a small but significant change to the `QwertyAaKeyModel` in the `QwertyKeyboard` implementation. The change updates the appearance of the key when it is not in a caps-locked state.

* [`AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyAaKeyModel.swift`](diffhunk://#diff-2898af63e4a2c39d06650571468795631551e9d3872246f2cf8ed8a48caef704L36-R36): Replaced the key label from an image (`textformat.alt`) to a text label (`Aa`) when the caps lock is not active. This likely improves clarity for users.