### PR TITLE
fix: タブバー編集画面の問題を修正

### DIFF
--- a/MainApp/Customize/EditingTabBarView.swift
+++ b/MainApp/Customize/EditingTabBarView.swift
@@ -249,6 +249,7 @@ private struct TabNavigationViewItemLabelTypePicker: View {
             Label("アイコン", systemImage: "heart.text.square.fill").tag(TabBarItemLabelType.LabelType.image)
         }
         .pickerStyle(.menu)
+        .labelStyle(.titleOnly)
     }
 }
 

--- a/MainApp/Customize/EditingTabBarView.swift
+++ b/MainApp/Customize/EditingTabBarView.swift
@@ -126,11 +126,11 @@ struct EditingTabBarView: View {
                             self.items.append(EditingTabBarItem(label: .image("keyboard.chevron.compact.down"), pinned: false, actions: [.dismissKeyboard]))
                         }
                     }
-                    Button("azooKeyを開く", systemImage: "gear") {
+                    Button("azooKeyを開く", systemImage: "gearshape") {
                         withAnimation(.interactiveSpring()) {
                             self.items.append(
                                 EditingTabBarItem(
-                                    label: .image("gear"),
+                                    label: .image("gearshape"),
                                     pinned: false,
                                     actions: [.launchApplication(.init(scheme: .azooKey, target: ""))]
                                 )

--- a/MainApp/Customize/EditingTabBarView.swift
+++ b/MainApp/Customize/EditingTabBarView.swift
@@ -278,6 +278,9 @@ private struct TabNavigationViewItemLabelEditView: View {
             TextField(placeHolder, text: $labelText)
                 .textFieldStyle(.roundedBorder)
                 .submitLabel(.done)
+                .onChange(of: labelText) { value in
+                    label = .text(value)
+                }
         case .image:
             SystemIconCompactPicker(icon: $labelText, recommendation: [
                 "keyboard.chevron.compact.down",

--- a/MainApp/Customize/EditingTabBarView.swift
+++ b/MainApp/Customize/EditingTabBarView.swift
@@ -236,10 +236,12 @@ private struct TabNavigationViewItemLabelTypePicker: View {
                 self.item.label.labelType
             },
             set: { (newValue: TabBarItemLabelType.LabelType) in
-                switch newValue {
-                case .text:
-                    self.item.label = .text("アイテム")
-                case .image:
+                switch (self.item.label, newValue) {
+                case (.text, .text), (.image, .image):
+                    break
+                case (.image, .text):
+                    self.item.label = .text("")
+                case (.text, .image):
                     self.item.label = .image("circle.fill")
                 }
             }


### PR DESCRIPTION
fix #509 
This pull request introduces several updates to the `EditingTabBarView.swift` file, focusing on improving the user interface and behavior of the tab bar editing experience. The most important changes include updating button icons, refining label type switching logic, enhancing picker styles, and dynamically updating text labels.

### User Interface Updates:

* Updated the icon for the "azooKeyを開く" button from `gear` to `gearshape` to align with system consistency.
* Added the `.labelStyle(.titleOnly)` modifier to the picker to improve its visual appearance by displaying only the title.

### Behavior Improvements:

* Refined the logic for switching label types in `TabNavigationViewItemLabelTypePicker` to handle transitions between `.text` and `.image` more robustly, avoiding unnecessary resets when the type remains the same.
* Added an `.onChange` handler to the text field in `TabNavigationViewItemLabelEditView` to dynamically update the label text as the user types, ensuring real-time synchronization.