### PR TITLE
repo: issueテンプレートのフォーマットを変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report--不具合の報告-.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--不具合の報告-.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report (不具合の報告)
 about: 不具合の修正のための情報提供
-title: "[BUG] Description of bug"
+title: "bug: <Description of bug>"
 labels: bug
 assignees: ''
 
@@ -30,6 +30,7 @@ If applicable, add screenshots to help explain your problem.
  - App Version [e.g. 1.9]
 
 **Is it possible to keep in touch with you on an ongoing basis to fix this bug? (バグの修正のため、継続的なやり取りは可能ですか？)**
+Yes/No
 
 **Additional context (その他共有したい事項があれば記述してください)**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request--機能の提案-.md
+++ b/.github/ISSUE_TEMPLATE/feature-request--機能の提案-.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request (機能の提案)
 about: Suggest an idea for azooKey (azooKeyへの機能の提案)
-title: "[Feature Request] Description of feature"
+title: "feat: <Description of feature>"
 labels: enhancement
 assignees: ''
 
@@ -17,6 +17,8 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **If we were to implement this feature, will you help implement it? (もし提案する機能を実装する場合、実装を手伝う余裕はありますか？)**
+<!--ご自身で実装が可能な提案はより受け入れられる可能性が高いです。-->
+Yes/No
 
 **Additional context (その他共有したい事項があれば記述してください)**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question--質問-.md
+++ b/.github/ISSUE_TEMPLATE/question--質問-.md
@@ -1,7 +1,7 @@
 ---
 name: Question (質問)
 about: Ask anything about azooKey
-title: "[Question]"
+title: "question: <Description of question>"
 labels: question
 assignees: ensan-hcl
 


### PR DESCRIPTION
This pull request updates the issue templates to improve clarity and consistency in titles and user responses. The changes include standardizing the title format across templates and adding prompts to encourage user engagement.

### Improvements to issue templates:

* [`.github/ISSUE_TEMPLATE/bug-report--不具合の報告-.md`](diffhunk://#diff-5cf4ec225d3a5faa5ac350c09efb0ee7cec7e589709a5e9c8df723584b320fdcL4-R4): Updated the title format to "bug: <Description of bug>" for consistency and added a "Yes/No" prompt to indicate if the user can assist with ongoing communication to fix the bug. [[1]](diffhunk://#diff-5cf4ec225d3a5faa5ac350c09efb0ee7cec7e589709a5e9c8df723584b320fdcL4-R4) [[2]](diffhunk://#diff-5cf4ec225d3a5faa5ac350c09efb0ee7cec7e589709a5e9c8df723584b320fdcR33)

* [`.github/ISSUE_TEMPLATE/feature-request--機能の提案-.md`](diffhunk://#diff-634335638f937fcf91fcbf081636b75f31ccc28f335fed9e4203a682b7211de2L4-R4): Changed the title format to "feat: <Description of feature>" and added a "Yes/No" prompt with a note encouraging users to implement their suggestions if possible. [[1]](diffhunk://#diff-634335638f937fcf91fcbf081636b75f31ccc28f335fed9e4203a682b7211de2L4-R4) [[2]](diffhunk://#diff-634335638f937fcf91fcbf081636b75f31ccc28f335fed9e4203a682b7211de2R20-R21)

* [`.github/ISSUE_TEMPLATE/question--質問-.md`](diffhunk://#diff-c527fab17182a686258670000b44874331c1dc84fd6239800898356faf21bd1cL4-R4): Standardized the title format to "question: <Description of question>" for better readability and alignment with other templates.