### PR TITLE
feat: use consistent label for both flick/qwerty by default

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/KeyboardSetting/FlickCustomKeyKeyboardSetting.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/KeyboardSetting/FlickCustomKeyKeyboardSetting.swift
@@ -86,8 +86,8 @@ public extension KeyboardSettingKey where Self == SymbolsTabFlickCustomKey {
 }
 
 public struct AbcTabFlickCustomKey: FlickCustomKeyKeyboardSetting {
-    public static let title: LocalizedStringKey = "「abc」キーのフリック割り当て"
-    public static let explanation: LocalizedStringKey = "「abc」キーの「上」「右」「下」フリックに、好きな操作を割り当てて利用することができます。"
+    public static let title: LocalizedStringKey = "「ABC」キーのフリック割り当て"
+    public static let explanation: LocalizedStringKey = "「ABC」キーの「上」「右」「下」フリックに、好きな操作を割り当てて利用することができます。"
     public static let identifier = CustomizableFlickKey.abcTab
     public static let key: String = "abc_tab_flick"
 }

--- a/AzooKeyCore/Sources/KeyboardViews/ExternalSetting/FlickCustomKeySetting.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/ExternalSetting/FlickCustomKeySetting.swift
@@ -52,7 +52,7 @@ public enum CustomizableFlickKey: String, Codable, Sendable {
         case .abcTab:
             return KeyFlickSetting(
                 identifier: self,
-                center: FlickCustomKey(label: "abc", actions: [.moveTab(.system(.user_english))]),
+                center: FlickCustomKey(label: "ABC", actions: [.moveTab(.system(.user_english))]),
                 left: FlickCustomKey(label: "", actions: []),
                 top: FlickCustomKey(label: "", actions: []),
                 right: FlickCustomKey(label: "→", actions: [.moveCursor(1)], longpressActions: .init(repeat: [.moveCursor(1)])),

--- a/AzooKeyCore/Sources/KeyboardViews/States.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/States.swift
@@ -17,16 +17,28 @@ public enum KeyboardLayout: String, CaseIterable, Equatable, Sendable {
 }
 
 extension KeyboardLanguage {
+    var shortSymbol: String {
+        switch self {
+        case .en_US:
+            "A"
+        case .el_GR:
+            "Ω"
+        case .ja_JP:
+            "あ"
+        case .none:
+            ""
+        }
+    }
     var symbol: String {
         switch self {
         case .en_US:
-            return "A"
+            "ABC"
         case .el_GR:
-            return "Ω"
+            "ΑΒΓ"
         case .ja_JP:
-            return "あ"
+            "あいう"
         case .none:
-            return ""
+            ""
         }
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/TabBarData.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/TabBarData.swift
@@ -101,7 +101,7 @@ public struct TabBarData: Codable, Sendable {
         TabBarItem(label: .image("aspectratio"), pinned: true, actions: [.enableResizingMode, .toggleTabBar]),
         TabBarItem(label: .image("face.smiling"), pinned: true, actions: [.moveTab(.system(.emoji_tab))]),
         TabBarItem(label: .text("あいう"), pinned: false, actions: [.moveTab(.system(.user_japanese))]),
-        TabBarItem(label: .image("abc"), pinned: false, actions: [.moveTab(.system(.user_english))]),
+        TabBarItem(label: .image("ABC"), pinned: false, actions: [.moveTab(.system(.user_english))]),
     ])
 }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -278,7 +278,7 @@ extension CustardInterfaceKey {
             case .flickHiraTab:
                 return SimpleKeyModel(keyLabelType: .text("あいう"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_japanese))])
             case .flickAbcTab:
-                return SimpleKeyModel(keyLabelType: .text("abc"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_english))])
+                return SimpleKeyModel(keyLabelType: .text("ABC"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.user_english))])
             case .flickStar123Tab:
                 return SimpleKeyModel(keyLabelType: .text("☆123"), unpressedKeyColorType: .special, pressActions: [.moveTab(.system(.flick_numbersymbols))])
             }

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyLanguageSwitchKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyLanguageSwitchKeyModel.swift
@@ -59,9 +59,9 @@ struct QwertySwitchLanguageKeyModel<Extension: ApplicationSpecificKeyboardViewEx
     func label<ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable>(width: CGFloat, theme: ThemeData<ThemeExtension>, states: VariableStates, color: Color?) -> KeyLabel<Extension> {
         let current = currentTabLanguage(variableStates: states)
         return if languages.0 == current {
-            KeyLabel(.selectable(languages.0.symbol, languages.1.symbol), width: width, textColor: color)
+            KeyLabel(.selectable(languages.0.shortSymbol, languages.1.shortSymbol), width: width, textColor: color)
         } else if languages.1 == current {
-            KeyLabel(.selectable(languages.1.symbol, languages.0.symbol), width: width, textColor: color)
+            KeyLabel(.selectable(languages.1.shortSymbol, languages.0.shortSymbol), width: width, textColor: color)
         } else if SemiStaticStates.shared.needsInputModeSwitchKey && [.ja_JP, .en_US, .el_GR].contains(states.keyboardLanguage) {
             KeyLabel(.text(states.keyboardLanguage.symbol), width: width, textColor: color)
         } else {

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyTabKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyTabKeyModel.swift
@@ -47,12 +47,12 @@ struct QwertyTabKeyModel<Extension: ApplicationSpecificKeyboardViewExtension>: Q
         case true:
             switch states.keyboardLanguage {
             case .ja_JP, .none, .el_GR:
-                return KeyLabel(.text("あ"), width: width, textColor: color)
+                return KeyLabel(.text("あいう"), width: width, textColor: color)
             case .en_US:
-                return KeyLabel(.text("A"), width: width, textColor: color)
+                return KeyLabel(.text("ABC"), width: width, textColor: color)
             }
         case false:
-            return KeyLabel(.text("あ"), width: width, textColor: color)
+            return KeyLabel(.text("あいう"), width: width, textColor: color)
         }
     }
 

--- a/MainApp/Setting/CustomKeys/FlickCustomKeys/FlickCustomKeySettingView.swift
+++ b/MainApp/Setting/CustomKeys/FlickCustomKeys/FlickCustomKeySettingView.swift
@@ -80,7 +80,7 @@ struct FlickCustomKeysSettingSelectView: View {
                 Text(verbatim: "小ﾞﾟ").tag(CustomizableFlickKey.kogana)
                 Text(verbatim: "､｡?!").tag(CustomizableFlickKey.kanaSymbols)
                 Text(verbatim: "あいう").tag(CustomizableFlickKey.hiraTab)
-                Text(verbatim: "abc").tag(CustomizableFlickKey.abcTab)
+                Text(verbatim: "ABC").tag(CustomizableFlickKey.abcTab)
                 Text(verbatim: "☆123").tag(CustomizableFlickKey.symbolsTab)
             }
             .pickerStyle(.segmented)


### PR DESCRIPTION
* 「abc」キーのラベルをOS標準と揃えて「ABC」に変更
* Qwertyで切替キーがある場合、「A」を「ABC」に、「あ」を「あいう」キーに変更
* 位置周りは変更無し