### PR TITLE
fix: recent emojiが頻繁に更新され過ぎる問題を修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
@@ -140,9 +140,6 @@ public final class VariableStates: ObservableObject {
 
     @Published public var upsideComponent: UpsideComponent?
 
-    // MARK: refresh用
-    @Published public var lastTabCharacterPreferenceUpdate = Date()
-
     /// 片手モード編集状態
     @Published private(set) var resizingState: ResizingState = .fullwidth
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/SpecialTabs/EmojiTab.swift
@@ -348,11 +348,11 @@ struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
             .frame(height: footerHeight)
         }
         .frame(width: variableStates.interfaceSize.width)
-        .onChange(of: variableStates.lastTabCharacterPreferenceUpdate) { _ in
-            self.emojis = Self.getEmojis(keyboardInternalSettingManager: variableStates.keyboardInternalSettingManager)
+        .onChange(of: self.selectedGenre) { _ in
+            self.updateEmojiData()
         }
         .onAppear {
-            self.emojis = Self.getEmojis(keyboardInternalSettingManager: variableStates.keyboardInternalSettingManager)
+            self.updateEmojiData()
             self.expandLevel = variableStates.keyboardInternalSettingManager.emojiTabExpandModePreference.level
             if !self.emojis[.recent, default: []].isEmpty {
                 self.selectedGenre = .recent
@@ -363,6 +363,12 @@ struct EmojiTab<Extension: ApplicationSpecificKeyboardViewExtension>: View {
         .onDisappear {
             variableStates.resultModel.setResults([])
         }
+    }
+
+    /// Recently Usedなどは更新される
+    /// - note: 更新頻度が高すぎると使い辛いので、あまり頻繁に呼ばない方がよい。表示を切り替えた場面などに限るとよい
+    private func updateEmojiData() {
+        self.emojis = Self.getEmojis(keyboardInternalSettingManager: variableStates.keyboardInternalSettingManager)
     }
 }
 
@@ -442,7 +448,6 @@ private struct EmojiKeyModel<Extension: ApplicationSpecificKeyboardViewExtension
     func additionalOnPress(variableStates: VariableStates) {
         variableStates.keyboardInternalSettingManager.update(\.tabCharacterPreference) { value in
             value.setUsed(base: self.base, for: .system(.emoji))
-            variableStates.lastTabCharacterPreferenceUpdate = Date()
         }
     }
     func pressActions(variableStates: VariableStates) -> [ActionType] {

--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -76,7 +76,6 @@ final class KeyboardActionManager: UserActionManager, @unchecked Sendable {
                     item.setPreference(base: candidate.base, replace: candidate.replace, for: .system(.emoji))
                 }
             }
-            variableStates.lastTabCharacterPreferenceUpdate = .now
         } else if let candidate = candidate as? PostCompositionPredictionCandidate {
             self.inputManager.input(text: candidate.text, simpleInsert: true, inputStyle: .direct)
             if !candidate.isTerminal {


### PR DESCRIPTION
これまでRecent Emojiは即時更新だったため、Recent Emoji内で絵文字を連打すると勝手に順序が入れ替わり、異なる絵文字が入力されてしまう問題があった。この問題は特に同じ絵文字を連打する際に深刻だった。

そこで、表示が更新されるタイミングをジャンルの切替時に絞り、Recent Emojiが表示されている間は更新が生じないようにした。