### PR TITLE
fix: 時おりshadowが表示されなくなっていた問題を修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyBackground.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyBackground.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct KeyBackground: View {
+    var backgroundColor: Color
+    var borderColor: Color
+    var borderWidth: CGFloat
+    var size: CGSize
+    var shadow: (color: Color, radius: CGFloat, x: CGFloat, y: CGFloat)
+    var blendMode: BlendMode
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .strokeAndFill(
+                fillContent: self.backgroundColor,
+                strokeContent: self.borderColor,
+                lineWidth: self.borderWidth
+            )
+            .frame(width: self.size.width, height: self.size.height)
+            .compositingGroup()
+            .shadow (
+                color: self.shadow.color,
+                radius: self.shadow.radius,
+                x: self.shadow.x,
+                y: self.shadow.y
+            )
+            .blendMode(self.blendMode)
+    }
+}

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/CustomKeyboard.swift
@@ -426,17 +426,12 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
 
     public var body: some View {
         ZStack {
-            let hasAllSuggest = self.suggestState.items.contains(where: {$0.value.contains(where: {$0.value == .all})})
-            let needKeyboardBlur = blur && hasAllSuggest
             ForEach(0..<layout.rowCount, id: \.self) {x in
                 let columnSuggestStates = self.suggestState.items[x, default: [:]]
-                // 可能ならカラムごとにblurをかけることで描画コストを減らす
-                let needColumnWideBlur = needKeyboardBlur && columnSuggestStates.allSatisfy {$0.value != .all}
                 ForEach(0..<layout.columnCount, id: \.self) {y in
                     if let data = models[.gridFit(x: x, y: y)] {
                         let info = flickKeyData(x: x, y: y, width: data.width, height: data.height)
                         let suggestState = columnSuggestStates[y]
-                        let needBlur = needKeyboardBlur && !needColumnWideBlur && suggestState == nil
                         contentGenerator(FlickKeyView(model: data.model, size: info.size, position: (x, y), suggestState: $suggestState), x, y)
                             .zIndex(suggestState != nil ? 1 : 0)
                             .overlay(alignment: .center) {
@@ -448,11 +443,9 @@ public struct CustardFlickKeysView<Extension: ApplicationSpecificKeyboardViewExt
                             .frame(width: info.contentSize.width, height: info.contentSize.height)
                             .contentShape(Rectangle())
                             .position(x: info.position.x, y: info.position.y)
-                            .opacity(needBlur ? 0.75 : 1.0)
                     }
                 }
                 .zIndex(columnSuggestStates.isEmpty ? 0 : 1)
-                .opacity(needColumnWideBlur ? 0.75 : 1.0)
             }
             .frame(width: tabDesign.keysWidth, height: tabDesign.keysHeight)
         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -48,13 +48,19 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
     public var body: some View {
         label(width: keyViewWidth)
             .background {
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeAndFill(
-                        fillContent: keyBackground.color.blendMode(keyBackground.blendMode),
-                        strokeContent: theme.borderColor.color,
-                        lineWidth: theme.borderWidth
-                    )
-                    .frame(width: keyViewWidth, height: keyViewHeight)
+                KeyBackground(
+                    backgroundColor: keyBackground.color,
+                    borderColor: theme.borderColor.color,
+                    borderWidth: theme.borderWidth,
+                    size: .init(width: keyViewWidth, height: keyViewHeight),
+                    shadow: (
+                        color: theme.keyShadow?.color.color ?? .clear,
+                        radius: theme.keyShadow?.radius ?? 0.0,
+                        x: theme.keyShadow?.x ?? 0,
+                        y: theme.keyShadow?.y ?? 0
+                    ),
+                    blendMode: keyBackground.blendMode
+                )
             }
             .frame(width: keyViewWidth, height: keyViewHeight)
             .overlay {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -224,9 +224,9 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
 
     private var keyBackgroundStyle: FlickKeyBackgroundStyleValue {
         if pressState.isActive() {
-            return model.backgroundStyleWhenPressed(theme: theme)
+            model.backgroundStyleWhenPressed(theme: theme)
         } else {
-            return model.backgroundStyleWhenUnpressed(states: variableStates, theme: theme)
+            model.backgroundStyleWhenUnpressed(states: variableStates, theme: theme)
         }
     }
 
@@ -244,17 +244,22 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
     }
 
     public var body: some View {
-        let keySize = (width: size.width, height: size.height)
-        RoundedRectangle(cornerRadius: 6)
-            .strokeAndFill(
-                fillContent: keyBackgroundStyle.color.shadow(keyShadow).blendMode(keyBackgroundStyle.blendMode),
-                strokeContent: keyBorderColor,
-                lineWidth: theme.borderWidth
-            )
-            .frame(width: keySize.width, height: keySize.height)
+        KeyBackground(
+            backgroundColor: keyBackgroundStyle.color,
+            borderColor: keyBorderColor,
+            borderWidth: theme.borderWidth,
+            size: size,
+            shadow: (
+                color: theme.keyShadow?.color.color ?? .clear,
+                radius: theme.keyShadow?.radius ?? 0.0,
+                x: theme.keyShadow?.x ?? 0,
+                y: theme.keyShadow?.y ?? 0
+            ),
+            blendMode: keyBackgroundStyle.blendMode
+        )
             .gesture(gesture)
             .overlay {
-                self.label(width: keySize.width)
+                self.label(width: size.width)
             }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -195,7 +195,7 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
             })
     }
 
-    var keyFillColor: QwertyKeyBackgroundStyleValue {
+    var keyBackgroundStyle: QwertyKeyBackgroundStyleValue {
         if self.pressState.isActive {
             self.model.backgroundStyleWhenPressed(theme: theme)
         } else {
@@ -234,29 +234,22 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
         self.model.label(width: width, theme: theme, states: variableStates, color: color)
     }
 
-    private var keyShadow: ShadowStyle {
-        .drop(
-            color: theme.keyShadow?.color.color ?? .clear,
-            radius: theme.keyShadow?.radius ?? 0.0,
-            x: theme.keyShadow?.x ?? 0,
-            y: theme.keyShadow?.y ?? 0
-        )
-    }
-
     var body: some View {
         ZStack(alignment: .bottom) {
             Group {
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeAndFill(
-                        fillContent: keyFillColor.color.shadow(keyShadow).blendMode(keyFillColor.blendMode),
-                        strokeContent: keyBorderColor,
-                        lineWidth: keyBorderWidth
-                    )
-                    .frame(width: size.width, height: size.height)
-                    .contentShape(
-                        Rectangle()
-                            .size(CGSize(width: size.width + tabDesign.horizontalSpacing, height: size.height + tabDesign.verticalSpacing))
-                    )
+                KeyBackground(
+                    backgroundColor: keyBackgroundStyle.color,
+                    borderColor: keyBorderColor,
+                    borderWidth: theme.borderWidth,
+                    size: size,
+                    shadow: (
+                        color: theme.keyShadow?.color.color ?? .clear,
+                        radius: theme.keyShadow?.radius ?? 0.0,
+                        x: theme.keyShadow?.x ?? 0,
+                        y: theme.keyShadow?.y ?? 0
+                    ),
+                    blendMode: keyBackgroundStyle.blendMode
+                )
                     .gesture(gesture)
                     .overlay {
                         label(width: size.width, color: nil)


### PR DESCRIPTION
厳密には原因不明だが、新テーマにおいてshadowが時おり表示されないことがあったので、実装を書き換えたところ良くなった。また、キーボードごとの表示の一貫性のため、`KeyBackground`の`View`を別途導入し、すべての環境でこれをベースとして使うようにした。