### PR TITLE
fix: タブバーボタンがこれまで3箇所に動いていたのを、2箇所に減らした

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/ResultBar.swift
@@ -23,7 +23,6 @@ private extension Equatable {
 
 @MainActor
 struct ResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
-    @Namespace private var namespace
     @Environment(Extension.Theme.self) private var theme
     @Environment(\.userActionManager) private var action
     @EnvironmentObject private var variableStates: VariableStates
@@ -47,16 +46,20 @@ struct ResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
     private var tabBarButton: some View {
         TabBarButton<Extension>()
             .zIndex(10)
-            .matchedGeometryEffect(id: "KeyboardBarButton", in: namespace)
     }
 
     var body: some View {
         Group {
             if variableStates.resultModel.displayState == .nothing {
-                CenterAlignedView {
+                HStack {
                     if displayTabBarButton {
                         tabBarButton
+                        if undoButtonAction != nil {
+                            Spacer()
+                        }
                     }
+                }
+                .overlay {
                     if let undoButtonAction {
                         Button("取り消す", systemImage: "arrow.uturn.backward") {
                             KeyboardFeedback<Extension>.click()
@@ -73,7 +76,7 @@ struct ResultBar<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                     }
                 }
                 .onChange(of: variableStates.undoAction.and(variableStates.textChangedCount)) {newValue in
-                    withAnimation(.easeIn(duration: 0.2)) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
                         if newValue.first?.textChangedCount == newValue.second {
                             self.undoButtonAction = newValue.first
                         } else {


### PR DESCRIPTION
これまでタブバーボタンの位置には3箇所あり
1. 入力なし：中央
2. 予測候補表示：左端
3. 「取り消し」表示：中央左側
となっていた。ボタンの位置がコロコロ変わるとよくないので、3を2に統合し、「取り消し」表示中も左端にタブバーボタンを置くように変更した