### PR TITLE
feat: フリックカスタムタブエディタの改善

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/Custard/CustardManager.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/Custard/CustardManager.swift
@@ -59,6 +59,11 @@ public struct CustardManagerIndex: Codable {
 }
 
 public struct CustardManager: CustardManagerProtocol {
+    public struct EditorState: Sendable, Hashable, Codable {
+        public var copiedKey: UserMadeKeyData?
+    }
+
+    public var editorState = EditorState()
     private static let directoryName = "custard/"
     private var index = CustardManagerIndex()
 

--- a/AzooKeyCore/Sources/SwiftUIUtils/HelpAlertButton.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/HelpAlertButton.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+public struct HelpAlertButton: View {
+    public init(_ explanation: LocalizedStringKey) {
+        self.explanation = explanation
+    }
+    var explanation: LocalizedStringKey
+
+    @State private var showAlert = false
+    public var body: some View {
+        Button {
+            showAlert = true
+        } label: {
+            Image(systemName: "questionmark.circle")
+        }
+        .alert(explanation, isPresented: $showAlert) {
+            Button("OK") {
+                self.showAlert = false
+            }
+        }
+    }
+}
+

--- a/MainApp/Customize/CodableActionDataEditor.swift
+++ b/MainApp/Customize/CodableActionDataEditor.swift
@@ -857,7 +857,7 @@ private struct ActionPicker: View {
                     process(.moveCursor(-1))
                 }
                 Button("文字の入力") {
-                    process(.input("😁"))
+                    process(.input(""))
                 }
                 Button("文字の削除") {
                     process(.delete(1))

--- a/MainApp/Customize/CustardInterfaceKeyEditor.swift
+++ b/MainApp/Customize/CustardInterfaceKeyEditor.swift
@@ -652,17 +652,20 @@ struct CustardInterfaceKeyEditor: View {
                     Section(header: Text("キーのサイズ")) {
                         sizePicker
                     }
+                    Section {
+                        keyPicker
+                    }
+                    Section {
+                        Button("クリア") {
+                            // variationsには操作をしない
+                            keyData.model[.custom].press_actions = [.input("")]
+                            keyData.model[.custom].longpress_actions = .none
+                            keyData.model[.custom].design = .init(label: .text(""), color: .normal)
+                        }.foregroundStyle(.red)
+                    }
                 }
             case .simple:
                 EmptyView()
-            }
-            Section {
-                keyPicker
-            }
-            Section {
-                Button("リセット") {
-                    keyData.model = .custom(.empty)
-                }.foregroundStyle(.red)
             }
             if let direction = position.flickDirection {
                 Button("クリア") {

--- a/MainApp/Customize/EditingScrollCustardView.swift
+++ b/MainApp/Customize/EditingScrollCustardView.swift
@@ -68,9 +68,15 @@ struct EditingScrollCustardView: CancelableEditor {
             Form {
                 TextField("タブの名前", text: $editingItem.tabName)
                     .submitLabel(.done)
-                Button("プレビュー") {
-                    UIApplication.shared.closeKeyboard()
-                    showPreview = true
+                if showPreview {
+                    Button("プレビューを閉じる") {
+                        showPreview = false
+                    }
+                } else {
+                    Button("プレビュー") {
+                        UIApplication.shared.closeKeyboard()
+                        showPreview = true
+                    }
                 }
                 DisclosureGroup("詳細設定") {
                     HStack {
@@ -109,7 +115,7 @@ struct EditingScrollCustardView: CancelableEditor {
                     }
                     .font(.title)
                 } else {
-                    Button("プレビュー", systemImage: "eye") {
+                    Button("プレビュー", systemImage: "play.circle") {
                         UIApplication.shared.closeKeyboard()
                         showPreview = true
                     }

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -45,7 +45,6 @@ struct EditingTenkeyCustardView: CancelableEditor {
     @StateObject private var variableStates = VariableStates(clipboardHistoryManagerConfig: ClipboardHistoryManagerConfig(), tabManagerConfig: TabManagerConfig(), userDefaults: UserDefaults.standard)
     @State private var editingItem: UserMadeTenKeyCustard
     @Binding private var manager: CustardManager
-    @State private var copiedKey: UserMadeKeyData?
 
     // MARK: UI表示系
     @State private var showPreview = false
@@ -204,17 +203,15 @@ struct EditingTenkeyCustardView: CancelableEditor {
                                 .border(Color.primary)
                         }
                         .contextMenu {
-                            // TODO: これ、OSのクリップボード使ったほうがいいのかも
-                            // TODO: Swap、DuplicateみたいなAPIも追加したい
                             Button("コピーする", systemImage: "doc.on.doc") {
-                                copiedKey = editingItem.keys[.gridFit(x: x, y: y)]
+                                self.manager.editorState.copiedKey = editingItem.keys[.gridFit(x: x, y: y)]
                             }
                             Button("ペーストする", systemImage: "doc.on.clipboard") {
-                                if let copiedKey {
+                                if let copiedKey = self.manager.editorState.copiedKey {
                                     editingItem.keys[.gridFit(x: x, y: y)] = copiedKey
                                 }
                             }
-                            .disabled(copiedKey == nil)
+                            .disabled(self.manager.editorState.copiedKey == nil)
                             Button("下に行を追加", systemImage: "plus") {
                                 editingItem.columnCount = Int(editingItem.columnCount)?.advanced(by: 1).description ?? editingItem.columnCount
                                 for px in 0 ..< Int(layout.rowCount) {

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -126,22 +126,28 @@ struct EditingTenkeyCustardView: CancelableEditor {
                 TextField("タブの名前", text: $editingItem.tabName)
                     .textFieldStyle(.roundedBorder)
                     .submitLabel(.done)
-                Button("プレビュー") {
-                    showPreview = true
-                    UIApplication.shared.closeKeyboard()
+                if showPreview {
+                    Button("プレビューを閉じる") {
+                        showPreview = false
+                    }
+                } else {
+                    Button("プレビュー") {
+                        UIApplication.shared.closeKeyboard()
+                        showPreview = true
+                    }
                 }
                 HStack {
-                    Text("縦方向キー数")
+                    Text("行の数")
                     Spacer()
-                    IntegerTextField("縦方向キー数", text: $editingItem.columnCount, range: 1 ... .max)
+                    IntegerTextField("行の数", text: $editingItem.columnCount, range: 1 ... .max)
                         .keyboardType(.numberPad)
                         .textFieldStyle(.roundedBorder)
                         .submitLabel(.done)
                 }
                 HStack {
-                    Text("横方向キー数")
+                    Text("列の数")
                     Spacer()
-                    IntegerTextField("横方向キー数", text: $editingItem.rowCount, range: 1 ... .max)
+                    IntegerTextField("列の数", text: $editingItem.rowCount, range: 1 ... .max)
                         .keyboardType(.numberPad)
                         .textFieldStyle(.roundedBorder)
                         .submitLabel(.done)
@@ -164,7 +170,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
                         showPreview = false
                     }
                 } else {
-                    Button("プレビュー", systemImage: "eye") {
+                    Button("プレビュー", systemImage: "play.circle") {
                         showPreview = true
                     }
                 }
@@ -309,6 +315,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
         .background(Color.secondarySystemBackground)
         .navigationBarBackButtonHidden(true)
         .navigationTitle(Text("カスタムタブを作る"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button("キャンセル", role: .cancel, action: {self.cancel()})

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -37,7 +37,7 @@ struct EditingTenkeyCustardView: CancelableEditor {
             dict[.gridFit(x: x, y: y)] = emptyKey
         }
     }
-    private static let emptyItem: UserMadeTenKeyCustard = .init(tabName: "新規タブ", rowCount: "5", columnCount: "4", inputStyle: .direct, language: .none, keys: emptyKeys, addTabBarAutomatically: true)
+    private static let emptyItem: UserMadeTenKeyCustard = .init(tabName: "新規タブ", rowCount: "5", columnCount: "4", inputStyle: .direct, language: .ja_JP, keys: emptyKeys, addTabBarAutomatically: true)
 
     @Environment(\.dismiss) private var dismiss
 

--- a/MainApp/Setting/BooleanSetting/BoolSettingView.swift
+++ b/MainApp/Setting/BooleanSetting/BoolSettingView.swift
@@ -9,9 +9,9 @@
 import AzooKeyUtils
 import KeyboardViews
 import SwiftUI
+import SwiftUIUtils
 
 struct BoolSettingView<SettingKey: BoolKeyboardSettingKey>: View {
-    @State private var showExplanation = false
     @State private var showRequireFullAccessAlert = false
     @State private var showOnEnabledMessageAlert = false
     @State private var onEnabledAlertMessage: LocalizedStringKey?
@@ -25,11 +25,7 @@ struct BoolSettingView<SettingKey: BoolKeyboardSettingKey>: View {
         Toggle(isOn: $setting.value) {
             HStack {
                 Text(SettingKey.title)
-                Button {
-                    showExplanation = true
-                } label: {
-                    Image(systemName: "questionmark.circle")
-                }
+                HelpAlertButton(SettingKey.explanation)
                 if SettingKey.requireFullAccess {
                     Image(systemName: "f.circle.fill")
                         .foregroundStyle(.purple)
@@ -62,11 +58,6 @@ struct BoolSettingView<SettingKey: BoolKeyboardSettingKey>: View {
                 }
             } else {
                 SettingKey.onDisabled()
-            }
-        }
-        .alert(SettingKey.explanation, isPresented: $showExplanation) {
-            Button("OK") {
-                self.showExplanation = false
             }
         }
         .alert(SettingKey.explanation, isPresented: $showRequireFullAccessAlert) {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1358,7 +1358,14 @@
       }
     },
     "Hotfix not found" : {
-      "shouldTranslate" : false
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotfix not found"
+          }
+        }
+      }
     },
     "iCloudから読み込む" : {
       "localizations" : {
@@ -2536,22 +2543,6 @@
         }
       }
     },
-    "キーの色を設定します。" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Set the color of this key."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
-          }
-        }
-      }
-    },
     "キーの表示サイズ" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3587,6 +3578,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : ""
+          }
+        }
+      }
+    },
+    "サブ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sub"
           }
         }
       }
@@ -5040,6 +5041,16 @@
         }
       }
     },
+    "プレビューを閉じる" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Preview"
+          }
+        }
+      }
+    },
     "ペースト" : {
       "localizations" : {
         "en" : {
@@ -5200,6 +5211,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Forbid earthworm emojis"
+          }
+        }
+      }
+    },
+    "メイン" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Main"
           }
         }
       }
@@ -6299,6 +6320,16 @@
         }
       }
     },
+    "列の数" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Column Count"
+          }
+        }
+      }
+    },
     "利用するもの" : {
       "localizations" : {
         "en" : {
@@ -6995,6 +7026,16 @@
         }
       }
     },
+    "大きく表示される文字を設定します。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set sub label displayed in larger font"
+          }
+        }
+      }
+    },
     "大きな文字で表示する" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7196,6 +7237,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : ""
+          }
+        }
+      }
+    },
+    "小さく表示される文字を設定します。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set sub label displayed in smaller font"
           }
         }
       }
@@ -9709,6 +9760,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Forbid mosquito emojis"
+          }
+        }
+      }
+    },
+    "行の数" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Row Count"
           }
         }
       }


### PR DESCRIPTION
複数のカイゼンを導入

* キーの編集画面でのシートの利用をやめ、キープレビューと編集画面を統合
* いくつかの説明文をはてなマークの中に突っ込んだ
* ラベルの種類を可能な限り「自動」に設定し、編集負荷を軽減
* 見えている必要のないビューをいくつか削除
* 命名を変更
* ナビゲーションタイトルバーを小さめに表示
* キーのタブ同士でのコピペを可能に
* プレビューのボタンをトグル式に変更
* 「文字を入力」アクションのデフォルトを空文字に変更