### PR TITLE
chore: change light longpress duration from 0.1 to 0.125

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeybaord/SimpleKeyView/SimpleKeyView.swift
@@ -41,9 +41,9 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
     private var longpressDuration: TimeInterval {
         switch self.model.longPressActions(variableStates: variableStates).duration {
         case .light:
-            0.10
+            0.125
         case .normal:
-            0.4
+            0.400
         }
     }
     private var keyBackground: SimpleKeyBackgroundStyleValue {

--- a/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/FlickKeyboard/KeyView/FlickKeyView.swift
@@ -73,9 +73,9 @@ public struct FlickKeyView<Extension: ApplicationSpecificKeyboardViewExtension>:
     private func longpressDuration(_ action: LongpressActionType) -> TimeInterval {
         switch action.duration {
         case .light:
-            0.10
+            0.125
         case .normal:
-            0.4
+            0.400
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/QwertyKeyboard/KeyView/QwertyKeyView.swift
@@ -121,9 +121,9 @@ struct QwertyKeyView<Extension: ApplicationSpecificKeyboardViewExtension>: View 
     private var longpressDuration: TimeInterval {
         switch self.model.longPressActions(variableStates: variableStates).duration {
         case .light:
-            0.10
+            0.125
         case .normal:
-            0.4
+            0.400
         }
     }
 


### PR DESCRIPTION
#500 のfollow-up。0.1秒だと誤判定が多いようなので、0.125秒に調整