### PR TITLE
fix: 余計な処理を行わないようにして、ViewControllerをシンプルに

### DIFF
--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -47,15 +47,6 @@ extension UIKeyboardType: @retroactive CustomDebugStringConvertible {
     }
 }
 
-extension UIView {
-    func clearAllView() {
-        self.subviews.forEach {
-            $0.clearAllView()
-        }
-        self.removeFromSuperview()
-    }
-}
-
 final class KeyboardViewController: UIInputViewController {
     private static var keyboardViewHost: KeyboardHostingController<Keyboard>?
     private static var loadedInstanceCount: Int = 0
@@ -65,7 +56,6 @@ final class KeyboardViewController: UIInputViewController {
         tabManagerConfig: TabManagerConfig(),
         userDefaults: UserDefaults.standard
     )
-    private static let notificationCenter = NotificationCenter.default
 
     struct Keyboard: View {
         let theme: AzooKeyTheme
@@ -98,7 +88,6 @@ final class KeyboardViewController: UIInputViewController {
         // 高さの設定を反映する
         @KeyboardSetting(.keyboardHeightScale) var keyboardHeightScale: Double
         SemiStaticStates.shared.setKeyboardHeightScale(keyboardHeightScale)
-        self.setupKeyboardView()
     }
 
     private func setupKeyboardView() {
@@ -149,10 +138,8 @@ final class KeyboardViewController: UIInputViewController {
         let size = self.rootParentViewController.view.bounds.size
         SemiStaticStates.shared.setScreenWidth(size.width)
         KeyboardViewController.variableStates.setInterfaceSize(orientation: UIScreen.main.bounds.width < UIScreen.main.bounds.height ? .vertical : .horizontal, screenWidth: size.width)
-        // 作文ツールなどでは、`viewWillDisappear`で消えた後、`viewDidLoad`を通らずに再びここに来ることがある
-        if KeyboardViewController.keyboardViewHost == nil {
-            self.setupKeyboardView()
-        }
+        // キーボードのセットアップはこの段階で行う
+        self.setupKeyboardView()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -168,14 +155,12 @@ final class KeyboardViewController: UIInputViewController {
             debug(#function, size)
         }
 
+        // viewDidAppearで実施する
         let window = self.view.window!
         let gr0 = window.gestureRecognizers![0] as UIGestureRecognizer
         let gr1 = window.gestureRecognizers![1] as UIGestureRecognizer
         gr0.delaysTouchesBegan = false
         gr1.delaysTouchesBegan = false
-
-        self.view.becomeFirstResponder()
-        self.updateViewConstraints()
     }
 
     func updateStates() {
@@ -191,13 +176,12 @@ final class KeyboardViewController: UIInputViewController {
             fatalError("Too many instance of KeyboardViewController was created")
         }
 
-        KeyboardViewController.action.setDelegateViewController(self)
-        KeyboardViewController.action.setResultViewUpdateCallback(Self.variableStates)
         SemiStaticStates.shared.setNeedsInputModeSwitchKey(self.needsInputModeSwitchKey)
         SemiStaticStates.shared.setHapticsAvailable()
         SemiStaticStates.shared.setHasFullAccess(self.hasFullAccess)
 
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
             @KeyboardSetting(.useOSUserDict) var useOSUserDict
             var dict: [DicdataElement] = []
             if useOSUserDict {
@@ -275,15 +259,8 @@ final class KeyboardViewController: UIInputViewController {
         debug("KeyboardViewController.viewWillDisappear: キーボードが閉じられます")
         KeyboardViewController.action.closeKeyboard()
         KeyboardViewController.variableStates.closeKeyboard()
-        KeyboardViewController.keyboardViewHost = nil
         KeyboardViewController.loadedInstanceCount -= 1
         super.viewWillDisappear(animated)
-        self.view.clearAllView()
-        self.keyboardHeightConstraint = nil
-        self.hostViewWidthConstraint = nil
-        self.hostViewBottomConstraint = nil
-        self.hostViewHeightConstraint = nil
-        self.removeFromParent()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
fix #489 

副作用が未知なのでしばらく運用してみる

- [x] iPhone 16 / iOS 18での動作確認（回転も問題なし）
- [x] iPad Pro / iOS 18での動作確認（回転・フローティングも問題なし）

### 既知の問題
作文ツール起動中にSiriを起動してタイプ入力しようとするとキーボードが出てこない
* 現在のコードではタイプ入力しようとするとキーボードが2重に出てくるので、どちらがマシかという問題になる