### PR TITLE
Fix clipboard history insertion bug

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/ClipboardHistoryManager.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/ClipboardHistoryManager.swift
@@ -111,8 +111,10 @@ public struct ClipboardHistoryManager {
             }
             if self.items.isEmpty {
                 self.items.append(item)
-            } else if let index = self.items.firstIndex(where: {item > $0}) {
+            } else if let index = self.items.firstIndex(where: { item > $0 }) {
                 self.items.insert(item, at: index)
+            } else {
+                self.items.append(item)
             }
         }
         // 増えすぎないように削除する


### PR DESCRIPTION
## Summary
- ensure new clipboard history items are added even when only pinned items exist

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/azooKey/CustardKit)*