### PR TITLE
fix: Add default tabbar fallback when saving custard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /Keyboard/Dictionary/louds/*.chid
 AzooKey-dict
 Package.resolved
+.swiftpm
 *.DS_Store
 __MACOSX/
 

--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -96,5 +96,11 @@ let package = Package(
                 "KeyboardExtensionUtils"
             ]
         ),
+        .testTarget(
+            name: "AzooKeyUtilsTests",
+            dependencies: [
+                "AzooKeyUtils"
+            ]
+        ),
     ]
 )

--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -85,6 +85,7 @@ let package = Package(
         .target(
             name: "KeyboardExtensionUtils",
             dependencies: [
+                .product(name: "CustardKit", package: "CustardKit"),
                 .product(name: "KanaKanjiConverterModule", package: "AzooKeyKanaKanjiConverter")
             ],
             resources: [],
@@ -93,13 +94,13 @@ let package = Package(
         .testTarget(
             name: "KeyboardExtensionUtilsTests",
             dependencies: [
-                "KeyboardExtensionUtils"
+                "KeyboardExtensionUtils",
             ]
         ),
         .testTarget(
             name: "AzooKeyUtilsTests",
             dependencies: [
-                "AzooKeyUtils"
+                "AzooKeyUtils",
             ]
         ),
     ]

--- a/AzooKeyCore/Sources/AzooKeyUtils/Custard/CustardManager.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/Custard/CustardManager.swift
@@ -157,11 +157,14 @@ public struct CustardManager: CustardManagerProtocol {
     }
 
     public mutating func addTabBar(identifier: Int = 0, item: TabBarItem) throws {
-        let tabbar = try self.tabbar(identifier: identifier)
-        let newTabBar = TabBarData(
-            identifier: tabbar.identifier,
-            items: tabbar.items + [item]
-        )
+        let tabbar: TabBarData
+        if let loaded = try? self.tabbar(identifier: identifier) {
+            tabbar = loaded
+        } else {
+            tabbar = .default
+        }
+        var newTabBar = tabbar
+        newTabBar.items.append(item)
         try self.saveTabBarData(tabBarData: newTabBar)
     }
 

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/CustardManagerTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/CustardManagerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import AzooKeyUtils
 import CustardKit
+import KeyboardViews
 
 final class CustardManagerTests: XCTestCase {
     func testSaveCustardCreatesTabBarWhenAbsent() throws {

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/CustardManagerTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/CustardManagerTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import AzooKeyUtils
+import CustardKit
+
+final class CustardManagerTests: XCTestCase {
+    func testSaveCustardCreatesTabBarWhenAbsent() throws {
+        var manager = CustardManager.load()
+        manager.removeTabBar(identifier: 0)
+        let custard = Custard.errorMessage
+        try manager.saveCustard(custard: custard, metadata: .init(origin: .userMade), updateTabBar: true)
+        let fileManager = FileManager.default
+        let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: SharedStore.appGroupKey)!
+        let fileURL = container.appendingPathComponent("custard/tabbar_0.tabbar")
+        XCTAssertTrue(fileManager.fileExists(atPath: fileURL.path))
+        let data = try Data(contentsOf: fileURL)
+        let tabbar = try JSONDecoder().decode(TabBarData.self, from: data)
+        XCTAssertTrue(tabbar.items.contains { $0.actions == [.moveTab(.custom(custard.identifier))] })
+    }
+}


### PR DESCRIPTION
fix: #443 
## Summary
- use `TabBarData.default` when tab bar is missing in `addTabBar`
- add `CustardManagerTests` validating automatic creation of tab bar
- extend package manifest with `AzooKeyUtilsTests` target
- remove changelog file per review

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/azooKey/CustardKit)*