### PR TITLE
fix: 「ぱ行が入力できない問題」を修正したバージョンに変更

### DIFF
--- a/MainApp/UpdateInformationView.swift
+++ b/MainApp/UpdateInformationView.swift
@@ -15,6 +15,12 @@ struct UpdateInformationView: View {
             Group {
                 // version 2.4系
                 Group {
+                    VersionView("2.4.1", releaseDate: "2025年05月21日") {
+                        ParagraphView("不具合を修正しました。") {
+                            "特定の文字の入力が不可能になっていた問題を修正しました"
+                        }
+
+                    }
                     VersionView("2.4", releaseDate: "2025年05月15日") {
                         if #unavailable(iOS 17) {
                             ParagraphView("お知らせ。") {

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -760,7 +760,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
@@ -796,7 +796,7 @@
 					"@executable_path/Frameworks",
 				);
 				LLVM_LTO = YES_THIN;
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
@@ -921,7 +921,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;
@@ -956,7 +956,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LLVM_LTO = YES_THIN;
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;


### PR DESCRIPTION
* これまで管理していたv2.4.1の更新はv2.4.2に先送りし、辞書のみを修正したv2.4.1をリリースする
* 本PRでは辞書を更新し、同時に最低限のv2.4.1に向けた変更のみを導入する