### PR TITLE
feat: カスタムタブ作成直後にカスタムタブの情報画面に遷移するように変更

### DIFF
--- a/MainApp/Customize/CustardInformationView.swift
+++ b/MainApp/Customize/CustardInformationView.swift
@@ -258,6 +258,7 @@ private final class ShareURL {
 struct CustardInformationView: View {
     private let initialCustard: Custard
     @Binding private var manager: CustardManager
+    @Binding private var path: [CustomizeTabView.Path]
     @State private var showActivityView = false
     @State private var exportedData = ShareURL()
     @State private var added = false
@@ -279,9 +280,10 @@ struct CustardInformationView: View {
 
     @State private var shareImage: CustardShareImage?
 
-    init(custard: Custard, manager: Binding<CustardManager>) {
+    init(custard: Custard, manager: Binding<CustardManager>, path: Binding<[CustomizeTabView.Path]> = .constant([])) {
         self.initialCustard = custard
         self._manager = manager
+        self._path = path
     }
 
     private var custard: Custard {
@@ -339,14 +341,14 @@ struct CustardInformationView: View {
                    let userdata = try? manager.userMadeCustardData(identifier: custard.identifier) {
                     switch userdata {
                     case let .gridScroll(value):
-                        NavigationLink("編集する", destination: EditingScrollCustardView(manager: $manager, editingItem: value))
+                        NavigationLink("編集する", destination: EditingScrollCustardView(manager: $manager, editingItem: value, path: $path))
                             .foregroundStyle(.accentColor)
                     case let .tenkey(value):
-                        NavigationLink("編集する", destination: EditingTenkeyCustardView(manager: $manager, editingItem: value))
+                        NavigationLink("編集する", destination: EditingTenkeyCustardView(manager: $manager, editingItem: value, path: $path))
                             .foregroundStyle(.accentColor)
                     }
                 } else if let editingItem = custard.userMadeTenKeyCustard {
-                    NavigationLink("編集する", destination: EditingTenkeyCustardView(manager: $manager, editingItem: editingItem))
+                    NavigationLink("編集する", destination: EditingTenkeyCustardView(manager: $manager, editingItem: editingItem, path: $path))
                         .foregroundStyle(.accentColor)
                 }
             }

--- a/MainApp/Customize/CustomizeTabView.swift
+++ b/MainApp/Customize/CustomizeTabView.swift
@@ -12,22 +12,27 @@ import SwiftUI
 import SwiftUIUtils
 
 struct CustomizeTabView: View {
+    enum Path: Hashable {
+        case information(String)
+    }
+
     @EnvironmentObject private var appStates: MainAppStates
     @Environment(\.requestReview) var requestReview
+    @State private var path: [Path] = []
 
     var body: some View {
         ZStack {
-            NavigationStack {
+            NavigationStack(path: $path) {
                 Form {
                     Section(header: Text("カスタムタブ")) {
                         ImageSlideshowView(pictures: [.custard1, .custard2, .custard3])
                             .listRowSeparator(.hidden, edges: .bottom)
                         Text("好きな文字や文章を並べたオリジナルのタブを作成することができます。")
-                        NavigationLink("カスタムタブの管理", destination: ManageCustardView(manager: $appStates.custardManager))
+                        NavigationLink("カスタムタブの管理", destination: ManageCustardView(manager: $appStates.custardManager, path: $path))
                             .foregroundStyle(.accentColor)
-                        NavigationLink("スクロール式のカスタムタブを作る", destination: EditingScrollCustardView(manager: $appStates.custardManager))
+                        NavigationLink("スクロール式のカスタムタブを作る", destination: EditingScrollCustardView(manager: $appStates.custardManager, path: $path))
                             .foregroundStyle(.accentColor)
-                        NavigationLink("フリック式のカスタムタブを作る", destination: EditingTenkeyCustardView(manager: $appStates.custardManager))
+                        NavigationLink("フリック式のカスタムタブを作る", destination: EditingTenkeyCustardView(manager: $appStates.custardManager, path: $path))
                             .foregroundStyle(.accentColor)
                     }
 
@@ -56,6 +61,14 @@ struct CustomizeTabView: View {
                 .onAppear {
                     if appStates.requestReviewManager.shouldTryRequestReview, appStates.requestReviewManager.shouldRequestReview() {
                         requestReview()
+                    }
+                }
+                .navigationDestination(for: Path.self) { destination in
+                    switch destination {
+                    case let .information(identifier):
+                        if let custard = try? appStates.custardManager.custard(identifier: identifier) {
+                            CustardInformationView(custard: custard, manager: $appStates.custardManager, path: $path)
+                        }
                     }
                 }
             }

--- a/MainApp/Customize/EditingScrollCustardView.swift
+++ b/MainApp/Customize/EditingScrollCustardView.swift
@@ -52,9 +52,11 @@ struct EditingScrollCustardView: CancelableEditor {
     @State private var addingItem = ""
     @State private var dragFrom: UUID?
     @StateObject private var variableStates = VariableStates(clipboardHistoryManagerConfig: ClipboardHistoryManagerConfig(), tabManagerConfig: TabManagerConfig(), userDefaults: UserDefaults.standard)
+    @Binding private var path: [CustomizeTabView.Path]
 
-    init(manager: Binding<CustardManager>, editingItem: UserMadeGridScrollCustard? = nil) {
+    init(manager: Binding<CustardManager>, editingItem: UserMadeGridScrollCustard? = nil, path: Binding<[CustomizeTabView.Path]> = .constant([])) {
         self._manager = manager
+        self._path = path
         self.base = editingItem ?? Self.emptyItem
         self._editingItem = State(initialValue: self.base)
     }
@@ -208,7 +210,11 @@ struct EditingScrollCustardView: CancelableEditor {
                 EditCancelButton()
             }
             ToolbarItem(placement: .topBarTrailing) {
-                SaveButton(saveAction: self.save)
+                Button("保存") {
+                    self.save()
+                    let custard = makeCustard(data: editingItem)
+                    path.append(.information(custard.identifier))
+                }
             }
         }
     }
@@ -251,19 +257,6 @@ struct EditingScrollCustardView: CancelableEditor {
         // required for `CancelableEditor` conformance, but in this view, it is treated by `EditCancelButton`
     }
 
-    // `NavigationStack`関連の問題で、`dismiss`を`EditingScrollCustardView`直下で実装するとNavigationLinkが上手く機能しなくなる
-    // この問題に対応するため、`dismiss`を利用するボタンを別途分けて実装した。
-    // see: https://developer.apple.com/forums/thread/720096
-    private struct SaveButton: View {
-        @Environment(\.dismiss) private var dismiss
-        var saveAction: () -> Void
-        var body: some View {
-            Button("保存") {
-                self.saveAction()
-                self.dismiss()
-            }
-        }
-    }
 }
 
 private struct DropViewDelegate: DropDelegate {

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -39,12 +39,11 @@ struct EditingTenkeyCustardView: CancelableEditor {
     }
     private static let emptyItem: UserMadeTenKeyCustard = .init(tabName: "新規タブ", rowCount: "5", columnCount: "4", inputStyle: .direct, language: .ja_JP, keys: emptyKeys, addTabBarAutomatically: true)
 
-    @Environment(\.dismiss) private var dismiss
-
     let base: UserMadeTenKeyCustard
     @StateObject private var variableStates = VariableStates(clipboardHistoryManagerConfig: ClipboardHistoryManagerConfig(), tabManagerConfig: TabManagerConfig(), userDefaults: UserDefaults.standard)
     @State private var editingItem: UserMadeTenKeyCustard
     @Binding private var manager: CustardManager
+    @Binding private var path: [CustomizeTabView.Path]
 
     // MARK: UI表示系
     @State private var showPreview = false
@@ -95,8 +94,9 @@ struct EditingTenkeyCustardView: CancelableEditor {
         )
     }
 
-    init(manager: Binding<CustardManager>, editingItem: UserMadeTenKeyCustard? = nil) {
+    init(manager: Binding<CustardManager>, editingItem: UserMadeTenKeyCustard? = nil, path: Binding<[CustomizeTabView.Path]> = .constant([])) {
         self._manager = manager
+        self._path = path
         self.baseSelectionSheetState = .init(hasShown: editingItem != nil)  // 編集の場合はすでにbase選択は終わったと考える
         self.base = editingItem ?? Self.emptyItem
         self._editingItem = State(initialValue: self.base)
@@ -320,7 +320,8 @@ struct EditingTenkeyCustardView: CancelableEditor {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("保存") {
                     self.save()
-                    self.dismiss()
+                    let saved = custard
+                    path.append(.information(saved.identifier))
                 }
             }
         }

--- a/MainApp/Customize/ManageCustardView.swift
+++ b/MainApp/Customize/ManageCustardView.swift
@@ -127,12 +127,14 @@ struct ManageCustardView: View {
     @State private var showAlert = false
     @State private var alertType: AlertType?
     @Binding private var manager: CustardManager
+    @Binding private var path: [CustomizeTabView.Path]
     @State private var webCustards: WebCustardList = .init(last_update: "", custards: [])
     @State private var showDocumentPicker = false
     @State private var selectedDocument: Data = Data()
     @State private var addTabBar = true
-    init(manager: Binding<CustardManager>) {
+    init(manager: Binding<CustardManager>, path: Binding<[CustomizeTabView.Path]> = .constant([])) {
         self._manager = manager
+        self._path = path
     }
 
     var body: some View {
@@ -144,20 +146,20 @@ struct ManageCustardView: View {
                     List {
                         ForEach(manager.availableCustards, id: \.self) {identifier in
                             if let custard = self.getCustard(identifier: identifier) {
-                                NavigationLink(identifier, destination: CustardInformationView(custard: custard, manager: $manager))
+                                NavigationLink(identifier, destination: CustardInformationView(custard: custard, manager: $manager, path: $path))
                                     .contextMenu {
                                         if let metadata = manager.metadata[custard.identifier],
                                            metadata.origin == .userMade,
                                            let userdata = try? manager.userMadeCustardData(identifier: custard.identifier) {
                                             switch userdata {
                                             case let .gridScroll(value):
-                                                IconNavigationLink("編集", systemImage: "slider.horizontal.3", destination: EditingScrollCustardView(manager: $manager, editingItem: value))
+                                                NavigationLink("編集", destination: EditingScrollCustardView(manager: $manager, editingItem: value, path: $path))
                                             case let .tenkey(value):
-                                                IconNavigationLink("編集", systemImage: "slider.horizontal.3", destination: EditingTenkeyCustardView(manager: $manager, editingItem: value))
+                                                NavigationLink("編集", destination: EditingTenkeyCustardView(manager: $manager, editingItem: value, path: $path))
                                             }
                                             Divider()
                                         } else if let editingItem = custard.userMadeTenKeyCustard {
-                                            IconNavigationLink("編集", systemImage: "slider.horizontal.3", destination: EditingTenkeyCustardView(manager: $manager, editingItem: editingItem))
+                                            NavigationLink("編集", destination: EditingTenkeyCustardView(manager: $manager, editingItem: editingItem, path: $path))
                                             Divider()
                                         }
                                         Button("削除", systemImage: "trash", role: .destructive) {
@@ -178,10 +180,10 @@ struct ManageCustardView: View {
 
             Section(header: Text("作る")) {
                 Text("登録したい文字や単語を順番に書いていくだけでスクロール式のカスタムタブを作成することができます。")
-                NavigationLink("スクロール式のカスタムタブを作る", destination: EditingScrollCustardView(manager: $manager))
+                NavigationLink("スクロール式のカスタムタブを作る", destination: EditingScrollCustardView(manager: $manager, path: $path))
                     .foregroundStyle(.accentColor)
                 Text("フリック式のカスタムタブを作成することができます。")
-                NavigationLink("フリック式のカスタムタブを作る", destination: EditingTenkeyCustardView(manager: $manager))
+                NavigationLink("フリック式のカスタムタブを作る", destination: EditingTenkeyCustardView(manager: $manager, path: $path))
                     .foregroundStyle(.accentColor)
             }
             if let custards = self.downloaderState.custards {


### PR DESCRIPTION
## Summary
- share one NavigationStack in CustomizeTabView
- pass its path binding into ManageCustardView and editing views
- push CustardInformationView onto that path after saving
- update related links and initializers

## Testing
- `swift test` *(fails: Could not find Package.swift)*