### PR TITLE
fix: safer makeChangeKeyboardButtonView impl for avoiding crash

### DIFF
--- a/Keyboard/Display/KeyboardActionManager.swift
+++ b/Keyboard/Display/KeyboardActionManager.swift
@@ -57,7 +57,7 @@ final class KeyboardActionManager: UserActionManager, @unchecked Sendable {
     }
 
     override func makeChangeKeyboardButtonView<Extension: ApplicationSpecificKeyboardViewExtension>() -> ChangeKeyboardButtonView<Extension> {
-        delegate.makeChangeKeyboardButtonView(size: Design.fonts.iconFontSize(keyViewFontSizePreference: Extension.SettingProvider.keyViewFontSize))
+        delegate?.makeChangeKeyboardButtonView(size: Design.fonts.iconFontSize(keyViewFontSizePreference: Extension.SettingProvider.keyViewFontSize)) ?? ChangeKeyboardButtonView(selector: nil, size: Design.fonts.iconFontSize(keyViewFontSizePreference: Extension.SettingProvider.keyViewFontSize))
     }
 
     /// 変換を確定した場合に呼ばれる。


### PR DESCRIPTION
`makeChangeKeyboardButtonView`が呼ばれた瞬間にクラッシュしたレポートがこの2週間で複数届いていた。unowned delegateがnilになっていたことによるエラーであるようなので、ひとまずnilの場合は見た目だけのものを返す実装にすることで安全にした。