### PR TITLE
fix: クラッシュする不具合を修正

### DIFF
--- a/MainApp/Customize/CustomizeTabView.swift
+++ b/MainApp/Customize/CustomizeTabView.swift
@@ -75,7 +75,7 @@ struct CustomizeTabView: View {
                     switch destination {
                     case let .information(identifier):
                         if let custard = try? appStates.custardManager.custard(identifier: identifier) {
-                            CustardInformationView(custard: custard, manager: $appStates.custardManager, path: $path)
+                            CustardInformationView(custard: custard, path: $path)
                         }
                     }
                 }

--- a/MainApp/Customize/ManageCustardView.swift
+++ b/MainApp/Customize/ManageCustardView.swift
@@ -149,7 +149,7 @@ struct ManageCustardView: View {
                         ForEach(manager.availableCustards, id: \.self) {identifier in
                             if let custard = self.getCustard(identifier: identifier) {
                                 NavigationLink(identifier) {
-                                    CustardInformationView(custard: custard, manager: $manager, path: $path)
+                                    CustardInformationView(custard: custard, path: $path)
                                 }
                                 .contextMenu {
                                     if let metadata = manager.metadata[custard.identifier],

--- a/MainApp/MainApp.swift
+++ b/MainApp/MainApp.swift
@@ -55,10 +55,11 @@ final class MainAppStates: ObservableObject {
 
 @main
 struct MainApp: App {
+    @StateObject private var appStates = MainAppStates()
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(MainAppStates())
+                .environmentObject(appStates)
                 .onAppear {
                     // MARK: セットアップ
                     SemiStaticStates.shared.setup()

--- a/MainApp/Setting/SettingTab.swift
+++ b/MainApp/Setting/SettingTab.swift
@@ -253,7 +253,7 @@ struct SettingTabView: View {
                 switch destination {
                 case let .information(identifier):
                     if let custard = try? appStates.custardManager.custard(identifier: identifier) {
-                        CustardInformationView(custard: custard, manager: $appStates.custardManager, path: $path)
+                        CustardInformationView(custard: custard, path: $path)
                     }
                 }
             }


### PR DESCRIPTION
* 特定端末で（環境依存で）`CustardInformationView`において「編集」を始めたときにクラッシュする問題があった
* 探索の結果、 #564 でこのエラーが入ったことがわかった
* 調査の結果、`MainAppStates`を`@EnvironmentObject`で受けた状態でさらに`@Binding`で`custardManager`を受けたのが原因と推定されたので、これを修正したところ、クラッシュする問題の解消を確認した
* 特にWarning/Errorが出ないので、今後再発しないよう注意が必要