### PR TITLE
feat: use OS-native stepper component

### DIFF
--- a/AzooKeyCore/Sources/SwiftUIUtils/BindingConvert.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/BindingConvert.swift
@@ -16,13 +16,13 @@ public extension Binding where Value: Sendable {
             }
         )
     }
-    func converted<Translator: Intertranslator>(_ translator: Translator.Type) -> Binding<Translator.Second> where Translator.First == Value {
+    func converted<Translator: Intertranslator>(_ translator: Translator) -> Binding<Translator.Second> where Translator.First == Value {
         .init(
             get: {
-                Translator.convert(self.wrappedValue)
+                translator.convert(self.wrappedValue)
             },
             set: {newValue in
-                self.wrappedValue = Translator.convert(newValue)
+                self.wrappedValue = translator.convert(newValue)
             }
         )
     }

--- a/AzooKeyCore/Sources/SwiftUIUtils/IntegerTextField.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/IntegerTextField.swift
@@ -9,19 +9,19 @@
 import SwiftUI
 
 public struct IntegerTextField: View {
-    public init(_ title: LocalizedStringKey, text: Binding<String>, range: ClosedRange<Int> = .min ... .max) {
-        self.title = title
+    public init(_ titleKey: LocalizedStringKey, text: Binding<String>, range: ClosedRange<Int> = .min ... .max) {
+        self.titleKey = titleKey
         self._text = text
         self.range = range
     }
 
-    private let title: LocalizedStringKey
+    private let titleKey: LocalizedStringKey
     private let range: ClosedRange<Int>
     @Binding private var text: String
 
     public var body: some View {
         HStack {
-            TextField(title, text: $text)
+            TextField(titleKey, text: $text)
                 .onChange(of: text) { newValue in
                     if let value = Int(newValue) {
                         if range.upperBound < value {
@@ -31,38 +31,20 @@ public struct IntegerTextField: View {
                         }
                     }
                 }
-            HStack(spacing: 0) {
-                Button {
-                    if let value = Int(text) {
-                        if value == range.upperBound {
-                            return
-                        }
+            Stepper() {
+                EmptyView()
+            } onIncrement: {
+                if let value = Int(text) {
+                    if range.upperBound > value {
                         text = "\(value + 1)"
                     }
-                } label: {
-                    Label("1増やす", systemImage: "plus")
-                        .padding(7)
-                        .contentShape(Rectangle())
                 }
-                .buttonStyle(.borderless)
-                Button {
-                    if let value = Int(text) {
-                        if value == range.lowerBound {
-                            return
-                        }
+            } onDecrement: {
+                if let value = Int(text) {
+                    if range.lowerBound < value {
                         text = "\(value - 1)"
                     }
-                } label: {
-                    Label("1減らす", systemImage: "minus")
-                        .padding(7)
-                        .contentShape(Rectangle())
                 }
-                .buttonStyle(.borderless)
-            }
-            .labelStyle(.iconOnly)
-            .background {
-                RoundedRectangle(cornerRadius: 5)
-                    .fill(Color.systemGray5)
             }
         }
     }

--- a/AzooKeyCore/Sources/SwiftUIUtils/Intertranslator.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/Intertranslator.swift
@@ -7,10 +7,55 @@
 //
 
 import Foundation
-public protocol Intertranslator {
+public protocol Intertranslator<First, Second>: Sendable {
     associatedtype First
     associatedtype Second
 
-    static func convert(_ first: First) -> Second
-    static func convert(_ second: Second) -> First
+    func convert(_ first: First) -> Second
+    func convert(_ second: Second) -> First
+}
+
+public struct IntStringConversion: Intertranslator {
+    public typealias First = Int
+    public typealias Second = String
+
+    public var defaultValue: Int = 1
+
+    public func convert(_ first: Int) -> String {
+        String(first)
+    }
+    public func convert(_ second: String) -> Int {
+        Int(second) ?? self.defaultValue
+    }
+}
+
+public extension Intertranslator where Self == IntStringConversion {
+    static func intStringConversion(defaultValue: Int = 1) -> Self {
+        IntStringConversion(defaultValue: defaultValue)
+    }
+}
+
+private struct ReversedIntertranslator<I: Intertranslator>: Intertranslator {
+    typealias First = I.Second
+    typealias Second = I.First
+    
+    private let intertranslator: I
+    
+    init(_ intertranslator: I) {
+        self.intertranslator = intertranslator
+    }
+
+    func convert(_ first: First) -> Second {
+        intertranslator.convert(first)
+    }
+
+    func convert(_ second: Second) -> First {
+        intertranslator.convert(second)
+    }
+}
+
+public extension Intertranslator {
+    func reversed() -> some Intertranslator<Self.Second, Self.First> {
+        ReversedIntertranslator(self)
+    }
 }

--- a/MainApp/Customize/CustardInterfaceKeyEditor.swift
+++ b/MainApp/Customize/CustardInterfaceKeyEditor.swift
@@ -410,22 +410,9 @@ fileprivate extension CustardInterfaceVariationKey {
     }
 }
 
-private struct IntStringConversion: Intertranslator {
-    typealias First = Int
-    typealias Second = String
-
-    static func convert(_ first: Int) -> String {
-        String(first)
-    }
-    static func convert(_ second: String) -> Int {
-        max(Int(second) ?? 1, 1)
-    }
-}
-
 @MainActor
 struct CustardInterfaceKeyEditor: View {
     @Binding private var keyData: UserMadeKeyData
-    private let intStringConverter = IntStringConversion.self
     private let target: Target
 
     @State private var selectedPosition: FlickKeyPosition = .center
@@ -558,20 +545,8 @@ struct CustardInterfaceKeyEditor: View {
     }
 
     @ViewBuilder private var sizePicker: some View {
-        HStack {
-            Text("縦")
-            IntegerTextField("縦", text: $keyData.height.converted(intStringConverter), range: 1 ... .max)
-                .keyboardType(.numberPad)
-                .textFieldStyle(.roundedBorder)
-                .submitLabel(.done)
-        }
-        HStack {
-            Text("横")
-            IntegerTextField("横", text: $keyData.width.converted(intStringConverter), range: 1 ... .max)
-                .keyboardType(.numberPad)
-                .textFieldStyle(.roundedBorder)
-                .submitLabel(.done)
-        }
+        Stepper("縦: \(keyData.height)", value: $keyData.height, in: 1 ... .max)
+        Stepper("横: \(keyData.width)", value: $keyData.width, in: 1 ... .max)
     }
 
     private func systemKeyEditor() -> some View {

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -153,18 +153,11 @@ struct EditingTenkeyCustardView: CancelableEditor {
                         showPreview = true
                     }
                 }
-                LabeledContent("行の数") {
-                    IntegerTextField("行の数", text: $editingItem.columnCount, range: 1 ... .max)
-                        .keyboardType(.numberPad)
-                        .textFieldStyle(.roundedBorder)
-                        .submitLabel(.done)
-                }
-                LabeledContent("列の数") {
-                    IntegerTextField("列の数", text: $editingItem.rowCount, range: 1 ... .max)
-                        .keyboardType(.numberPad)
-                        .textFieldStyle(.roundedBorder)
-                        .submitLabel(.done)
-                }
+
+                let columnCount: Binding<Int> = $editingItem.columnCount.converted(.intStringConversion(defaultValue: 1).reversed())
+                Stepper("行の数: \(editingItem.columnCount)", value: columnCount, in: 1 ... .max)
+                let rowCount: Binding<Int> = $editingItem.rowCount.converted(.intStringConversion(defaultValue: 1).reversed())
+                Stepper("列の数: \(editingItem.rowCount)", value: rowCount, in: 1 ... .max)
                 Picker("言語", selection: $editingItem.language) {
                     Text("なし").tag(CustardLanguage.none)
                     Text("日本語").tag(CustardLanguage.ja_JP)

--- a/MainApp/Theme/ThemeEditView.swift
+++ b/MainApp/Theme/ThemeEditView.swift
@@ -19,11 +19,11 @@ private struct ThemeColorTranslator: Intertranslator {
     typealias First = AzooKeyTheme.ColorData
     typealias Second = Color
 
-    static func convert(_ first: AzooKeyTheme.ColorData) -> Color {
+    func convert(_ first: AzooKeyTheme.ColorData) -> Color {
         first.color
     }
 
-    static func convert(_ second: Color) -> AzooKeyTheme.ColorData {
+    func convert(_ second: Color) -> AzooKeyTheme.ColorData {
         .color(second)
     }
 }
@@ -32,11 +32,11 @@ private struct ThemeSpecialKeyColorTranslator: Intertranslator {
     typealias First = AzooKeyTheme.ColorData
     typealias Second = Color
 
-    static func convert(_ first: AzooKeyTheme.ColorData) -> Color {
-        ThemeColorTranslator.convert(first)
+    func convert(_ first: AzooKeyTheme.ColorData) -> Color {
+        ThemeColorTranslator().convert(first)
     }
 
-    static func convert(_ second: Color) -> AzooKeyTheme.ColorData {
+    func convert(_ second: Color) -> AzooKeyTheme.ColorData {
         if let keyColor = ColorTools.rgba(second, process: {r, g, b, opacity in
             Color(.displayP3, red: r, green: g, blue: b, opacity: max(0.001, opacity))
         }) {
@@ -50,11 +50,11 @@ private struct ThemeNormalKeyColorTranslator: Intertranslator {
     typealias First = AzooKeyTheme.ColorData
     typealias Second = Color
 
-    static func convert(_ first: AzooKeyTheme.ColorData) -> Color {
-        ThemeColorTranslator.convert(first)
+    func convert(_ first: AzooKeyTheme.ColorData) -> Color {
+        ThemeColorTranslator().convert(first)
     }
 
-    static func convert(_ second: Color) -> AzooKeyTheme.ColorData {
+    func convert(_ second: Color) -> AzooKeyTheme.ColorData {
         if let keyColor = ColorTools.rgba(second, process: {r, g, b, opacity in
             Color(.displayP3, red: r, green: g, blue: b, opacity: max(0.001, opacity))
         }) {
@@ -68,11 +68,11 @@ private struct ThemeFontDoubleTranslator: Intertranslator {
     typealias First = ThemeFontWeight
     typealias Second = Double
 
-    static func convert(_ first: First) -> Second {
+    func convert(_ first: First) -> Second {
         Double(first.rawValue)
     }
 
-    static func convert(_ second: Second) -> First {
+    func convert(_ second: Second) -> First {
         ThemeFontWeight(rawValue: Int(second)) ?? .regular
     }
 }
@@ -93,9 +93,9 @@ struct ThemeEditView: CancelableEditor {
     @State private var pickedImage: UIImage?
     @State private var viewType = ViewType.editor
 
-    private let colorConverter = ThemeColorTranslator.self
-    private let normalColorConverter = ThemeNormalKeyColorTranslator.self
-    private let specialColorConverter = ThemeSpecialKeyColorTranslator.self
+    private let colorConverter = ThemeColorTranslator()
+    private let normalColorConverter = ThemeNormalKeyColorTranslator()
+    private let specialColorConverter = ThemeSpecialKeyColorTranslator()
 
     private enum ViewType {
         case editor
@@ -155,7 +155,7 @@ struct ThemeEditView: CancelableEditor {
                     Section(header: Text("文字")) {
                         HStack {
                             Text("文字の太さ")
-                            Slider(value: $theme.textFont.converted(ThemeFontDoubleTranslator.self), in: 1...9.9)
+                            Slider(value: $theme.textFont.converted(ThemeFontDoubleTranslator()), in: 1...9.9)
                         }
                     }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -6420,12 +6420,12 @@
         }
       }
     },
-    "列の数" : {
+    "列の数: %@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Column Count"
+            "value" : "Column Count: %@"
           }
         }
       }
@@ -8657,6 +8657,16 @@
         }
       }
     },
+    "横: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Width: %lld"
+          }
+        }
+      }
+    },
     "横方向キー数" : {
       "localizations" : {
         "en" : {
@@ -9686,6 +9696,16 @@
         }
       }
     },
+    "縦: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Height: %lld"
+          }
+        }
+      }
+    },
     "縦方向キー数" : {
       "localizations" : {
         "en" : {
@@ -9966,12 +9986,12 @@
         }
       }
     },
-    "行の数" : {
+    "行の数: %@" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Row Count"
+            "value" : "Row Count: %@"
           }
         }
       }


### PR DESCRIPTION
* 標準コンポーネントの`Stepper`を用いるように変更した。`-`と`+`の順序が入れ替わっている
* 小さな値しか扱わないと考えられる位置ではStepperを用い、IntegerTextFieldは使わないように変更した