### PR TITLE
feat: 編集キャンセルのconfirmationを省略できるときは省略

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
@@ -160,7 +160,7 @@ public struct UserMadeGridScrollCustard: Codable, Sendable {
     }
 }
 
-public struct UserMadeTenKeyCustard: Codable, Sendable {
+public struct UserMadeTenKeyCustard: Codable, Sendable, Equatable {
     public init(tabName: String, rowCount: String, columnCount: String, inputStyle: CustardInputStyle, language: CustardLanguage, keys: [KeyPosition: UserMadeKeyData], emptyKeys: Set<KeyPosition> = [], addTabBarAutomatically: Bool) {
         self.tabName = tabName
         self.rowCount = rowCount

--- a/AzooKeyCore/Sources/SwiftUIUtils/EditCancelButton.swift
+++ b/AzooKeyCore/Sources/SwiftUIUtils/EditCancelButton.swift
@@ -1,13 +1,20 @@
 import SwiftUI
 
 public struct EditCancelButton: View {
-    public init() {}
+    public init(confirmationRequired: Bool = true) {
+        self.confirmationRequired = confirmationRequired
+    }
 
+    private let confirmationRequired: Bool
     @State private var showCancellationAlert: Bool = false
     @Environment(\.dismiss) private var dismiss
     public var body: some View {
         Button("キャンセル", role: .cancel) {
-            self.showCancellationAlert = true
+            if confirmationRequired {
+                self.showCancellationAlert = true
+            } else {
+                self.dismiss()
+            }
         }
         .alert("編集を中止します。変更はすべて失われます。", isPresented: $showCancellationAlert) {
             Button("編集を中止する", role: .destructive) {

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -322,7 +322,8 @@ struct EditingTenkeyCustardView: CancelableEditor {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
-                EditCancelButton()
+                let hasChanges: Bool = self.base != self.editingItem
+                EditCancelButton(confirmationRequired: hasChanges)
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button("保存") {


### PR DESCRIPTION
開発中めんどくさかったので簡単に実装した。もう少しconfirmationを省略可能なケースは多いが、best effortということで