### PR TITLE
fix: 学習が意図せずにリセットされる問題を修正

### DIFF
--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         // MARK: `_: .upToNextMinor(Version)` or `exact: Version` or `revision: Version`.
         // MARK: For develop branch, you can use `revision:` specification.
         // MARK: For main branch, you must use `upToNextMinor` specification.
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.8.1"),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.8.5"),
         .package(url: "https://github.com/azooKey/CustardKit", revision: "3185363fd0eb9a14facd4aaa42070ba8f958a3c3"),
     ],
     targets: [

--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/ThemeManager.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/ThemeManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import KeyboardThemes
-import SwiftUICore
+import SwiftUI
 import SwiftUtils
 import UIKit
 


### PR DESCRIPTION
本Pull Requestでは、学習データが本来の仕様である32日間保持されるべきところ、数日単位でリセットされてしまう問題を修正します。調査の結果、「起動直後に何も操作せずにキーボードを閉じる」操作によりリセットが発生することを突き止めました。これは、本来`convertRequestOptions`がDicdataStoreに送信され、その後`LearningManager.save()`が呼ばれるべき処理経路が、「何も操作しない」ケースでは存在せず、デフォルト値で処理されるためにリセットが発生していたことがわかりました。

該当の処理をAZKKC側で修正し、デフォルト値を`nil`にしておくことで不適切なオプションのまま処理が進むことを防止するようにしました。この変更はAZKKCのv0.8.5以降で利用可能なため、この新しい実装を参照するように変更しました。
* https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/204