### PR TITLE
片手モードに「キーボードの高さ」設定を統合する機能の実装

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/InternalSettings/OneHandedModeSetting.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/InternalSettings/OneHandedModeSetting.swift
@@ -49,6 +49,12 @@ public struct OneHandedModeSetting: Sendable, Codable, StaticInitialValueAvailab
         }
     }
 
+    mutating func reset(layout: KeyboardLayout, orientation: KeyboardOrientation) {
+        // 対応する設定項目に、新しい空のインスタンスを代入して上書きする
+        // これにより、hasUsedフラグもfalseに戻るため、setIfFirstが機能するようになる
+        self[keyPath: keyPath(layout: layout, orientation: orientation)] = OneHandedModeSettingItem()
+    }
+
 }
 
 struct OneHandedModeSettingItem: Sendable, Codable {

--- a/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
@@ -310,4 +310,25 @@ public final class VariableStates: ObservableObject {
             self.interfacePosition = item.position
         }
     }
+
+    @MainActor
+    func resetOneHandedModeSetting() {
+        // 設定管理オブジェクトを通じて、oneHandedModeSettingを更新する
+        keyboardInternalSettingManager.update(\.oneHandedModeSetting) { setting in
+            // ステップ1: まず、カスタム設定をまっさらな状態にリセットする
+            setting.reset(layout: self.keyboardLayout, orientation: self.keyboardOrientation)
+
+            // ステップ2: 次に、リセットされた項目に「本来のデフォルト値」を再設定する
+            let defaultHeight = Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth, orientation: self.keyboardOrientation) + Design.keyboardScreenBottomPadding
+            let defaultSize = CGSize(width: SemiStaticStates.shared.screenWidth, height: defaultHeight)
+            setting.setIfFirst(layout: self.keyboardLayout, orientation: self.keyboardOrientation, size: defaultSize, position: .zero, forced: true) // forced: trueで確実に上書きする
+        }
+
+        // `updateResizingState()`を呼んで、UIに即時反映させる
+        // これにより、リセット後の正しいデフォルトサイズが画面に表示される
+        DispatchQueue.main.async {
+            self.updateResizingState()
+        }
+    }
+
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -26,7 +26,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
 
     private let initialSize: CGSize
     private let minimumWidth: CGFloat = 120
-    // private let minimumHeight: CGFloat = 120
+    private let minimumHeight: CGFloat = 120
 
     init(size: Binding<CGSize>, position: Binding<CGPoint>, initialSize: CGSize) {
         self._size = size
@@ -121,12 +121,15 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                 let new_py = (top_left_edge.current.y + bottom_right_edge.current.y - initialSize.height) / 2
 
                 // 以下のいずれかの条件に合致する場合、変更を無効にする
-                // 1. 操作対象が上ハンドルで、かつ新しい高さがデフォルトの高さを超えた場合
+                // 新しい高さが、定義した最小値を下回った場合
+                let isTooShort = newHeight < self.minimumHeight
+                // 2. 操作対象が上ハンドルで、かつ新しい高さがデフォルトの高さを超えた場合
                 let isTooTall = isTopHandle && newHeight > self.initialSize.height
-                // 2. キーボード全体が描画領域外に出てしまう場合 (既存のチェック)
+                // 3. キーボード全体が描画領域外に出てしまう場合
                 let isOutOfBounds = new_py < -initialSize.height / 2 || new_py > initialSize.height / 2
 
-                if isTooTall || isOutOfBounds {
+                // isTooShort をチェック条件に追加
+                if isTooShort || isTooTall || isOutOfBounds {
                     // 条件に合致した場合、Y座標をドラッグ前の値に戻す
                     self[keyPath: target].wrappedValue.current.y = before_y
                 } else {

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -239,14 +239,8 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                 Button {
                     KeyboardFeedback<Extension>.reset()
                     withAnimation(.interactiveSpring()) {
-                        self.position = .zero
-                        self.size.width = initialSize.width
-                        self.size.height = initialSize.height
+                        variableStates.resetOneHandedModeSetting()
                     }
-                    self.top_left_edge = (.zero, .zero)
-                    self.bottom_right_edge = (.init(x: initialSize.width, y: initialSize.height), .init(x: initialSize.width, y: initialSize.height))
-                    self.initialPosition = .zero
-                    self.updateUserDefaults()
                 } label: {
                     Circle()
                         .fill(Color.red)

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -192,18 +192,16 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
             }
             .stroke(Color.white, lineWidth: 3)
             .gesture(xGesture(target: \.$top_left_edge))
-            /*
-             Path {path in
-             for i in 0..<4 {
-             let y = size.height / 24 * CGFloat(i)
-             let ratio = (1 - CGFloat(i) / 4) * 0.8
-             path.move(to: CGPoint(x: size.width / 2 - size.width * edgeRatio * ratio, y: y))
-             path.addLine(to: CGPoint(x: size.width / 2 + size.width * edgeRatio * ratio, y: y))
-             }
-             }
-             .stroke(Color.white, lineWidth: 3)
-             .gesture(yGesture(target: \.$top_left_edge))
-             */
+            Path {path in
+                for i in 0..<4 {
+                    let y = size.height / 24 * CGFloat(i)
+                    let ratio = (1 - CGFloat(i) / 4) * 0.8
+                    path.move(to: CGPoint(x: size.width / 2 - size.width * edgeRatio * ratio, y: y))
+                    path.addLine(to: CGPoint(x: size.width / 2 + size.width * edgeRatio * ratio, y: y))
+                }
+            }
+            .stroke(Color.white, lineWidth: 3)
+            .gesture(yGesture(target: \.$top_left_edge))
             Path {path in
                 for i in 0..<4 {
                     let x = size.width - size.width / 24 * CGFloat(i)

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -118,24 +118,19 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
 
                 // 新しい高さと中心位置を計算
                 let newHeight = abs(bottom_right_edge.current.y - top_left_edge.current.y)
-                let new_py = (top_left_edge.current.y + bottom_right_edge.current.y - initialSize.height) / 2
 
                 // 以下のいずれかの条件に合致する場合、変更を無効にする
-                // [修正点 1/2]新しい高さが、定義した最小値を下回った場合
+                // 新しい高さが、定義した最小値を下回った場合
                 let isTooShort = newHeight < self.minimumHeight
-                // 2. 操作対象が上ハンドルで、かつ新しい高さがデフォルトの高さを超えた場合
-                let isTooTall = isTopHandle && newHeight > self.initialSize.height
-                // 3. キーボード全体が描画領域外に出てしまう場合
-                let isOutOfBounds = new_py < -initialSize.height / 2 || new_py > initialSize.height / 2
 
                 // isTooShort をチェック条件に追加
-                if isTooShort || isTooTall || isOutOfBounds {
+                if isTooShort {
                     // 条件に合致した場合、Y座標をドラッグ前の値に戻す
                     self[keyPath: target].wrappedValue.current.y = before_y
                 } else {
                     // 条件に合わなければ、計算結果を適用する
                     self.size.height = newHeight
-                    self.position.y = new_py
+                    //self.position.y = new_py
                 }
             }
             .onEnded {_ in
@@ -416,13 +411,9 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
             if !hideResetButtonInOneHandedMode && !isAtDefaultWidth {
                 editButton()
             }
-            let userScreenHeight = Design.keyboardHeight(
-                screenWidth: SemiStaticStates.shared.screenWidth,
-                orientation: variableStates.keyboardOrientation
-            )
             content
-                .frame(width: size.width, height: userScreenHeight)
-                .offset(x: position.x, y: position.y)
+                .frame(width: size.width, height: size.height)
+                .offset(x: position.x, y: 0)
         case .fullwidth:
             content
         case .resizing:


### PR DESCRIPTION
## Issue
feat: #535

## 概要
片手モード使用時にキーボードの高さをユーザーが調整できるようにし、その設定が即座にキーボードに反映されるように修正しました。エミュレーター上では正常に動作することを確認していますが、実機での確認は現在の環境では行えておりません。あと設定画面からキーボードの高さの項目をまだ削除しておりません。
まずはレビューをお願いできればと思います。

1. `ResizingRect`にて、コメントアウトされていたキーボード高さ調整用のハンドル表示処理を有効化。
2. EditButton を、キーボード幅が full（全幅）でない場合のみ表示されるように変更。
3. `KeyboardViewController` の `viewDidLoad` 内で `variableStates.$interfaceSize` を監視し、サイズ変更時にキーボードの高さ制約を更新する処理を追加。
4. `ResizingRect` の `yGesture` 内で `self.position.y = py` を削除し、不必要な上部の空白が生じないように調整。
