### PR TITLE
「片手モードに「キーボードの高さ」設定を統合する機能の実装」の追加の修正

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/Design.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Design.swift
@@ -147,28 +147,17 @@ public enum Design {
     /// screenWidthに依存して決定する
     /// 12はresultViewのpadding
     @MainActor public static func keyboardHeight(screenWidth: CGFloat, orientation: KeyboardOrientation, upsideComponent: UpsideComponent? = nil) -> CGFloat {
-        let scale: CGFloat
-        if let upsideComponent {
-            switch orientation {
-            case .vertical:
-                scale = min(2.2, SemiStaticStates.shared.keyboardHeightScale + upsideComponentScale(upsideComponent).vertical)
-            case .horizontal:
-                scale = min(2.2, SemiStaticStates.shared.keyboardHeightScale + upsideComponentScale(upsideComponent).horizontal)
-            }
-        } else {
-            scale = SemiStaticStates.shared.keyboardHeightScale
-        }
         // 安全装置として、widthが本来のscreenWidthを超えないようにする。
         let width = min(screenWidth, SemiStaticStates.shared.screenWidth)
         switch layoutMode(orientation: orientation) {
         case .phoneVertical:
-            return 51 / 74 * width * scale + 12
+            return 51 / 74 * width + 12
         case .padVertical:
-            return 15 / 31 * width * scale + 12
+            return 15 / 31 * width + 12
         case .phoneHorizontal:
-            return 17 / 56 * width * scale + 12
+            return 17 / 56 * width + 12
         case .padHorizontal:
-            return 5 / 18 * width * scale + 12
+            return 5 / 18 * width + 12
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/VariableStates.swift
@@ -145,6 +145,10 @@ public final class VariableStates: ObservableObject {
 
     @Published public var maximumHeight: CGFloat = 0
 
+    // 以前の KeyboardHeightSettingView を取得する
+    @Published public var heightScaleFromKeyboardHeightSetting: CGFloat = 1
+    private var userHasOverwrittenHeightScaleFromKeyboardHeightSetting: Bool = false
+
     /// 周囲のテキストが変化した場合にインクリメントする値。変化の検出に利用する。
     /// - note: この値がどれだけ変化するかは実装によるので、変化量は意味をなさない。
     @Published public var textChangedCount: Int = 0
@@ -179,20 +183,17 @@ public final class VariableStates: ObservableObject {
     @MainActor public func setResizingMode(_ state: ResizingState) {
         switch state {
         case .fullwidth:
-            // fullwidthへのリセットは変更なし
             interfaceSize = .init(width: SemiStaticStates.shared.screenWidth, height: Design.keyboardHeight(screenWidth: SemiStaticStates.shared.screenWidth, orientation: self.keyboardOrientation) + 2)
             interfacePosition = .zero
 
         case .onehanded:
-            // リサイズ完了時(.onehandedへの遷移)は、現在のinterfaceSizeを信頼する。
-            // ストレージからの再読み込みは行わず、何もしない(break)。
-            // これにより、競合状態を防ぎ、保持されている最新の高さが使われる。
+
             break
 
         case .resizing:
             // リサイズ開始時は、保存された値から初期状態を読み込むので変更なし
             let item = keyboardInternalSettingManager.oneHandedModeSetting.item(layout: keyboardLayout, orientation: keyboardOrientation)
-            interfaceSize = CGSize(width: min(item.size.width, SemiStaticStates.shared.screenWidth), height: item.size.height)
+            interfaceSize = CGSize(width: min(item.size.width, SemiStaticStates.shared.screenWidth), height: item.size.height * heightScaleFromKeyboardHeightSetting)
             interfacePosition = item.position
         }
 
@@ -316,11 +317,11 @@ public final class VariableStates: ObservableObject {
         }
         switch self.resizingState {
         case .fullwidth:
-            self.interfaceSize = CGSize(width: screenWidth, height: height)
+            self.interfaceSize = CGSize(width: screenWidth, height: height * heightScaleFromKeyboardHeightSetting)
         case .onehanded, .resizing:
             let item = keyboardInternalSettingManager.oneHandedModeSetting.item(layout: layout, orientation: orientation)
             // 安全のため、指示されたwidth, heightを超える値を許可しない。
-            self.interfaceSize = CGSize(width: min(screenWidth, item.size.width), height: item.size.height)
+            self.interfaceSize = CGSize(width: min(screenWidth, item.size.width), height: item.size.height * heightScaleFromKeyboardHeightSetting)
             self.interfacePosition = item.position
         }
     }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -392,21 +392,9 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                     .frame(width: r, height: r)
                     .contentShape(Circle())
 
-                    let button4 = Button {
-                        variableStates.maximumHeight += 32
-                    } label: {
-                        Circle().fill(Color.blue)
-                            .overlay {
-                                Image(systemName: "arrow.up").foregroundStyle(.white).font(.system(size: r * 0.5))
-                            }
-                    }
-                    .frame(width: r, height: r)
-                    .contentShape(Circle())
-
                     button1
                     button2
                     button3
-                    button4
                 }
                 Spacer()
             }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -170,32 +170,6 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
 
     var body: some View {
         ZStack {
-            /*
-             Path{path in
-             path.move(to: CGPoint(x: 0, y: height * edgeRatio))
-             path.addLine(to: CGPoint(x: 0, y: 0))
-             path.addLine(to: CGPoint(x: width * edgeRatio, y: 0))
-             }.stroke(edgeColor, lineWidth: lineWidth)
-             .gesture(gesture(x: \.$top_left_edge.x, y: \.$top_left_edge.y))
-             Path{path in
-             path.move(to: CGPoint(x: width, y: height * edgeRatio))
-             path.addLine(to: CGPoint(x: width, y: 0))
-             path.addLine(to: CGPoint(x: width * (1-edgeRatio), y: 0))
-             }.stroke(edgeColor, lineWidth: lineWidth)
-             .gesture(gesture(x: \.$bottom_right_edge.x, y: \.$top_left_edge.y, left: false))
-             Path{path in
-             path.move(to: CGPoint(x: 0, y: height * (1-edgeRatio)))
-             path.addLine(to: CGPoint(x: 0, y: height))
-             path.addLine(to: CGPoint(x: width * edgeRatio, y: height))
-             }.stroke(edgeColor, lineWidth: lineWidth)
-             .gesture(gesture(x: \.$top_left_edge.x, y: \.$bottom_right_edge.y, top: false))
-             Path{path in
-             path.move(to: CGPoint(x: width, y: height * (1-edgeRatio)))
-             path.addLine(to: CGPoint(x: width, y: height))
-             path.addLine(to: CGPoint(x: width * (1-edgeRatio), y: height))
-             }.stroke(edgeColor, lineWidth: lineWidth)
-             .gesture(gesture(x: \.$bottom_right_edge.x, y: \.$bottom_right_edge.y, top: false, left: false))
-             */
             Path {path in
                 for i in 0..<4 {
                     let x = size.width / 24 * CGFloat(i)
@@ -226,17 +200,6 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
             }
             .stroke(Color.white, lineWidth: 3)
             .gesture(xGesture(target: \.$bottom_right_edge))
-            /*
-             Path{path in
-             for i in 0..<4{
-             let y = height - height / 24 * CGFloat(i)
-             let ratio = (1 - CGFloat(i) / 4) * 0.8
-             path.move(to: CGPoint(x: width / 2 - width * edgeRatio * ratio, y: y))
-             path.addLine(to: CGPoint(x: width / 2 + width * edgeRatio * ratio, y: y))
-             }
-             }.stroke(Color.white, lineWidth: 3)
-             .gesture(yGesture(y: \.$bottom_right_edge.y, top: false))
-             */
             HStack {
                 let cur = min(size.width, size.height) * 0.22
                 let max = min(initialSize.width, initialSize.height) * 0.22
@@ -343,7 +306,6 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
 
         let r = min(fittableR, UIMaxButtonDiameter) * 0.9
 
-        // --- 2. 表示/非表示の決定 ---
         // 計算の結果、ボタンがタップできる十分な大きさを持つ場合のみ表示する
         if r >= 16 {
             // 上下にSpacerを持つコンテナVStackを追加し、垂直中央揃えを強制する

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -254,6 +254,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                     KeyboardFeedback<Extension>.reset()
                     withAnimation(.interactiveSpring()) {
                         variableStates.resetOneHandedModeSetting()
+                        variableStates.heightScaleFromKeyboardHeightSetting = 1
                     }
                 } label: {
                     Circle()
@@ -271,6 +272,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                     } else {
                         variableStates.setResizingMode(.onehanded)
                     }
+                    variableStates.heightScaleFromKeyboardHeightSetting = 1
                 } label: {
                     Circle()
                         .fill(Color.blue)

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -253,7 +253,7 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                         .fill(Color.blue)
                         .frame(width: r, height: r)
                         .overlay {
-                            Image(systemName: "arrow.up")
+                            Image(systemName: "arrow.up.to.line.compact")
                                 .foregroundStyle(.white)
                                 .font(.system(size: r * 0.5))
                         }

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -204,15 +204,6 @@ struct ResizingRect<Extension: ApplicationSpecificKeyboardViewExtension>: View {
                 let cur = min(size.width, size.height) * 0.22
                 let max = min(initialSize.width, initialSize.height) * 0.22
                 let r = min(cur, max)
-                Circle()
-                    .fill(Color.blue)
-                    .frame(width: r, height: r)
-                    .overlay {
-                        Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
-                            .foregroundStyle(.white)
-                            .font(Font.system(size: r * 0.5))
-                    }
-                    .gesture(moveGesture)
                 Button {
                     KeyboardFeedback<Extension>.reset()
                     withAnimation(.interactiveSpring()) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/ResizingRect.swift
@@ -306,6 +306,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                 VStack(spacing: spacing) {
                     let button1 = Button {
                         variableStates.setResizingMode(.resizing)
+                        variableStates.heightScaleFromKeyboardHeightSetting = 1
                     } label: {
                         Circle().fill(Color.blue)
                             .overlay {
@@ -317,6 +318,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
 
                     let button2 = Button {
                         variableStates.setResizingMode(.fullwidth)
+                        variableStates.heightScaleFromKeyboardHeightSetting = 1
                     } label: {
                         Circle().fill(Color.blue)
                             .overlay {
@@ -333,6 +335,7 @@ struct ResizingBindingFrame<Extension: ApplicationSpecificKeyboardViewExtension>
                             self.size = initialSize
                             variableStates.setResizingMode(.fullwidth)
                         }
+                        variableStates.heightScaleFromKeyboardHeightSetting = 1
                         variableStates.keyboardInternalSettingManager.update(\.oneHandedModeSetting) {value in
                             value.set(layout: variableStates.keyboardLayout, orientation: variableStates.keyboardOrientation, size: initialSize, position: .zero)
                         }

--- a/Keyboard/Display/KeyboardViewController.swift
+++ b/Keyboard/Display/KeyboardViewController.swift
@@ -88,17 +88,7 @@ final class KeyboardViewController: UIInputViewController {
         // 初期化の順序としてこの位置に置くこと
         KeyboardViewController.variableStates.initialize()
 
-        // 以前の高さの設定を反映する
-        @KeyboardSetting(.keyboardHeightScale) var keyboardHeightScale: Double
-        guard keyboardHeightScale != 1 else { return }
-
-        let defaults = UserDefaults.standard
-        let key = "user_has_overwritten_keyboard_height_setting"
-
-        let heightScaleToApply = defaults.bool(forKey: key) ? 1.0 : keyboardHeightScale
-        KeyboardViewController.variableStates.heightScaleFromKeyboardHeightSetting = heightScaleToApply
-
-        defaults.set(true, forKey: key)
+        self.setupInitialKeyboardHeight()
 
         let layout = KeyboardViewController.variableStates.keyboardLayout
         let orientation = KeyboardViewController.variableStates.keyboardOrientation
@@ -185,6 +175,20 @@ final class KeyboardViewController: UIInputViewController {
         @unknown default:
             return (try? indexManager.theme(at: indexManager.selectedIndex)) ?? defaultTheme
         }
+    }
+
+    private func setupInitialKeyboardHeight() {
+        @KeyboardSetting(.keyboardHeightScale) var keyboardHeightScale: Double
+
+        guard keyboardHeightScale != 1 else { return }
+
+        let defaults = UserDefaults.standard
+        let key = "user_has_overwritten_keyboard_height_setting"
+
+        let heightScaleToApply = defaults.bool(forKey: key) ? 1.0 : keyboardHeightScale
+        KeyboardViewController.variableStates.heightScaleFromKeyboardHeightSetting = heightScaleToApply
+
+        defaults.set(true, forKey: key)
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## 概要
- 片手モード時の「↑」ボタンを削除
- 以前の KeyboardHeight の設定を反映させる
- ResizingRect内のコメントアウトしている部分を削除する
- キーボードを上下左右に動かすボタンの削除
- ↑ボタンのアイコンの変更

### 以前の KeyboardHeight の設定を反映させる
`heightScaleFromKeyboardHeightSetting` を VariableStates 内に新規作成
UserDefaults `user_has_overwritten_keyboard_height_setting`  を作成して
` @KeyboardSetting(.keyboardHeightScale)` が 1 以外であれば、heightScaleFromKeyboardHeightSetting に keyboardHeightScale を代入する。

