### PR TITLE
feat: AzooKeyKanaKanjiConverterをv0.9.0に更新し、破壊的変更に対処

### DIFF
--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         // MARK: `_: .upToNextMinor(Version)` or `exact: Version` or `revision: Version`.
         // MARK: For develop branch, you can use `revision:` specification.
         // MARK: For main branch, you must use `upToNextMinor` specification.
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", from: "0.8.5"),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", branch: "031f3f466c0972b6db97192869be5c146a07a815"),
         .package(url: "https://github.com/azooKey/CustardKit", revision: "3185363fd0eb9a14facd4aaa42070ba8f958a3c3"),
     ],
     targets: [

--- a/Keyboard/Display/InputManager.swift
+++ b/Keyboard/Display/InputManager.swift
@@ -313,7 +313,7 @@ final class InputManager {
     /// 変換を選択した場合に呼ばれる
     @MainActor func complete(candidate: Candidate) {
         self.updateLog(candidate: candidate)
-        self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
+        self.composingText.prefixComplete(composingCount: candidate.composingCount)
         if self.displayedTextManager.shouldSkipMarkedTextChange {
             self.previousSystemOperation = .setMarkedText
         }
@@ -382,7 +382,7 @@ final class InputManager {
             candidate = Candidate(
                 text: composingText.convertTarget,
                 value: -18,
-                correspondingCount: composingText.input.count,
+                composingCount: .inputCount(composingText.input.count),
                 lastMid: MIDData.一般.mid,
                 data: [
                     DicdataElement(
@@ -400,7 +400,7 @@ final class InputManager {
         candidate.parseTemplate()
         self.updateLog(candidate: candidate)
         if shouldModifyDisplayedText {
-            self.composingText.prefixComplete(correspondingCount: candidate.correspondingCount)
+            self.composingText.prefixComplete(composingCount: candidate.composingCount)
             if self.displayedTextManager.shouldSkipMarkedTextChange {
                 self.previousSystemOperation = .setMarkedText
             }

--- a/Keyboard/Display/LiveConversionManager.swift
+++ b/Keyboard/Display/LiveConversionManager.swift
@@ -48,7 +48,7 @@ final class LiveConversionManager {
             var clause = Candidate.makePrefixClauseCandidate(data: data)
             // ローマ字向けに補正処理を入れる
             if count == 0, let first = firstClauseCandidates.first(where: {$0.text == clause.text}) {
-                clause.correspondingCount = first.correspondingCount
+                clause.composingCount = first.composingCount
             }
             if self.headClauseCandidateHistories.count <= count {
                 self.headClauseCandidateHistories.append([clause])
@@ -69,7 +69,7 @@ final class LiveConversionManager {
         if convertTargetCursorPosition > 1, let firstCandidate = candidates.first(where: {$0.data.map {$0.ruby}.joined().count == convertTarget.count}) {
             candidate = firstCandidate
         } else {
-            candidate = .init(text: convertTarget, value: 0, correspondingCount: composingText.input.count, lastMid: MIDData.一般.mid, data: [.init(ruby: convertTarget.toKatakana(), cid: CIDData.一般名詞.cid, mid: MIDData.一般.mid, value: 0)])
+            candidate = .init(text: convertTarget, value: 0, composingCount: .inputCount(composingText.input.count), lastMid: MIDData.一般.mid, data: [.init(ruby: convertTarget.toKatakana(), cid: CIDData.一般名詞.cid, mid: MIDData.一般.mid, value: 0)])
         }
         self.adjustCandidate(candidate: &candidate)
         debug("Live Conversion:", candidate)
@@ -102,12 +102,12 @@ final class LiveConversionManager {
                 self.updateHistories(newCandidate: candidate, firstClauseCandidates: firstClauseCandidates)
             } else if diff < 0 {
                 // 削除の場合には最後尾のログを1つ落とす。
-                self.headClauseCandidateHistories.mutatingForeach {
+                self.headClauseCandidateHistories.mutatingForEach {
                     _ = $0.popLast()
                 }
             } else {
                 // 置換の場合には更新を追加で入れる。
-                self.headClauseCandidateHistories.mutatingForeach {
+                self.headClauseCandidateHistories.mutatingForEach {
                     _ = $0.popLast()
                 }
                 self.updateHistories(newCandidate: candidate, firstClauseCandidates: firstClauseCandidates)
@@ -123,7 +123,7 @@ final class LiveConversionManager {
         if let last = candidate.data.last, last.ruby.count < 2 {
             let ruby_hira = last.ruby.toHiragana()
             let newElement = DicdataElement(word: ruby_hira, ruby: last.ruby, lcid: last.lcid, rcid: last.rcid, mid: last.mid, value: last.adjustedData(0).value(), adjust: last.adjust)
-            var newCandidate = Candidate(text: candidate.data.dropLast().map {$0.word}.joined() + ruby_hira, value: candidate.value, correspondingCount: candidate.correspondingCount, lastMid: candidate.lastMid, data: candidate.data.dropLast() + [newElement])
+            var newCandidate = Candidate(text: candidate.data.dropLast().map {$0.word}.joined() + ruby_hira, value: candidate.value, composingCount: candidate.composingCount, lastMid: candidate.lastMid, data: candidate.data.dropLast() + [newElement])
             newCandidate.parseTemplate()
             debug(candidate, newCandidate)
             candidate = newCandidate

--- a/Keyboard/Display/PredictionManager.swift
+++ b/Keyboard/Display/PredictionManager.swift
@@ -24,7 +24,7 @@ final class PredictionManager {
         result.text += right.text
         result.data += right.data
         result.value += right.value
-        result.correspondingCount += right.correspondingCount
+        result.composingCount = .composite(lhs: result.composingCount, rhs: right.composingCount)
         result.lastMid = right.lastMid == MIDData.EOS.mid ? left.lastMid : right.lastMid
         return result
     }

--- a/MainApp/Customize/EditingTenkeyCustardView.swift
+++ b/MainApp/Customize/EditingTenkeyCustardView.swift
@@ -736,7 +736,7 @@ extension CustardInterfaceCustomKey {
         self.press_actions = self.press_actions.map(transform)
         self.longpress_actions.start = self.longpress_actions.start.map(transform)
         self.longpress_actions.repeat = self.longpress_actions.repeat.map(transform)
-        self.variations.mutatingForeach { variation in
+        self.variations.mutatingForEach { variation in
             variation.key.press_actions = variation.key.press_actions.map(transform)
             variation.key.longpress_actions.start = variation.key.longpress_actions.start.map(transform)
             variation.key.longpress_actions.repeat = variation.key.longpress_actions.repeat.map(transform)


### PR DESCRIPTION
このPRではAzooKeyKanaKanjiConverterのバージョンを現状のv0.8.5からv0.9系（beta）に更新する。機能的な変更としては以下のような変更が取り込まれる。特に https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/223 により、長く問題となっていた`ComposingText`の`input`が破壊される問題が解消され、 #164 が解消される予定である。

* 誤り訂正と辞書引きの統合処理の実装により、変換の大幅な高速化を実現 by @ensan-hcl in https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/211
* Template関連の処理にcoarse filterを導入して高速化 by @ensan-hcl in https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/214
* 起動時の処理の安定化 by @mtgto in https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/217
* Lattice処理を二重インデックス化し、ComposingTextレベルで扱っていたアドホックな処理を削除 by @ensan-hcl https://github.com/azooKey/AzooKeyKanaKanjiConverter/pull/223

なお、このほかにv0.9.0ではいくつかのAPIの破壊的変更が生じるため、本PRではこれにも対処している。大きなものとしては、`Candidate.correspondingCount`が型違いの`Candidate.composingCount`に変更になったほか、`mutatingForeach`関数が`mutatingForEach`に変更になった。

fix: #164