### PR TITLE
feat(theme): MinimumとTechnoテーマを追加

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/AzooKeySpecificTheme.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/AzooKeySpecificTheme.swift
@@ -10,6 +10,30 @@ import Foundation
 import KeyboardThemes
 import KeyboardViews
 import SwiftUI
+import UIKit
+
+private enum SystemThemeColors {
+    typealias Components = (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+
+    static let minimumNormal = color(light: (0, 0, 0, 0.22), dark: (1, 1, 1, 0.26))
+    static let minimumSpecial = color(light: (0, 0, 0, 0.52), dark: (1, 1, 1, 0.56))
+    static let minimumPushed = color(light: (0.86, 0.87, 0.89, 1), dark: (0.16, 0.16, 0.18, 0.98))
+    static let minimumSuggest = color(light: (0.93, 0.93, 0.95, 1), dark: (0.16, 0.16, 0.18, 0.98))
+    static let minimumSuggestText = color(light: (0.08, 0.08, 0.09, 1), dark: (1, 1, 1, 1))
+    static let technoAccent = color(light: (0.95, 0.34, 0.06, 0.95), dark: (0.96, 0.76, 0.36, 0.92))
+    static let technoNormal = color(light: (1, 1, 1, 1), dark: (0.025, 0.03, 0.04, 0.9))
+    static let technoPushed = color(light: (0.929, 0.933, 0.949, 1), dark: (0.76, 0.52, 0.22, 0.96))
+    static let technoSpecial = color(light: (0.87, 0.88, 0.9, 1), dark: (0.045, 0.055, 0.075, 0.92))
+    static let technoText = color(light: (0.055, 0.07, 0.09, 1), dark: (0.96, 0.76, 0.36, 1))
+    static let technoShadow = color(light: (0, 0, 0, 0.14), dark: (0, 0, 0, 0.35))
+
+    private static func color(light: Components, dark: Components) -> Color {
+        Color(uiColor: UIColor { traits in
+            let value = traits.userInterfaceStyle == .dark ? dark : light
+            return UIColor(red: value.red, green: value.green, blue: value.blue, alpha: value.alpha)
+        })
+    }
+}
 
 public enum AzooKeySpecificTheme: ApplicationSpecificTheme {
     public enum ApplicationColor: ApplicationSpecificColor {
@@ -56,6 +80,44 @@ public extension AzooKeyTheme {
         suggestLabelTextColor: .color(Color(.displayP3, white: 0, opacity: 1)),
         keyShadow: nil
     )
+
+    /// A keyless typographic theme: labels float over a small orientation mark.
+    static let minimum: Self = {
+        var theme = AzooKeySpecificTheme.native
+        theme.textFont = .light
+        theme.style = .minimal
+        theme.borderWidth = 1.5
+        theme.normalKeyFillColor = .color(SystemThemeColors.minimumNormal)
+        theme.specialKeyFillColor = .color(SystemThemeColors.minimumSpecial)
+        theme.pushedKeyFillColor = .color(SystemThemeColors.minimumPushed)
+        theme.suggestKeyFillColor = .color(SystemThemeColors.minimumSuggest)
+        theme.suggestLabelTextColor = .color(SystemThemeColors.minimumSuggestText)
+        theme.keyShadow = nil
+        return theme
+    }()
+
+    /// Chamfered instrument panels with a technical light/dark interpretation.
+    static let techno: Self = {
+        var theme = AzooKeySpecificTheme.native
+        theme.textColor = .color(SystemThemeColors.technoText)
+        theme.textFont = .semibold
+        theme.style = .faceted
+        theme.borderColor = .color(SystemThemeColors.technoAccent)
+        theme.borderWidth = 0.8
+        theme.normalKeyFillColor = .color(SystemThemeColors.technoNormal)
+        theme.specialKeyFillColor = .color(SystemThemeColors.technoSpecial)
+        theme.pushedKeyFillColor = .color(SystemThemeColors.technoPushed)
+        theme.suggestKeyFillColor = theme.specialKeyFillColor
+        theme.suggestLabelTextColor = theme.textColor
+        theme.keyShadow = .init(
+            color: .color(SystemThemeColors.technoShadow),
+            radius: 2,
+            x: 0,
+            y: 2
+        )
+        return theme
+    }()
+
 }
 
 extension AzooKeySpecificTheme: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable {

--- a/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/ThemeManager.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/AzooKeyTheme/ThemeManager.swift
@@ -15,6 +15,8 @@ import UIKit
 struct ThemeIndices: Codable, Equatable {
     static var defaultThemeIndex: Int { 0 }
     static var classicDefaultThemeIndex: Int { -1 }
+    static var minimumThemeIndex: Int { -2 }
+    static var technoThemeIndex: Int { -3 }
     var currentIndices: [Int] = [0]
     var selectedIndex: Int = 0
     var selectedIndex_dark: Int = 0
@@ -47,6 +49,10 @@ struct ThemeIndices: Codable, Equatable {
 
 public struct ThemeIndexManager: Equatable {
     private var index: ThemeIndices
+
+    init(index: ThemeIndices) {
+        self.index = index
+    }
 
     private static func fileURL(name: String) -> URL {
         let directoryPath = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: SharedStore.appGroupKey)!
@@ -97,6 +103,10 @@ public struct ThemeIndexManager: Equatable {
             "Classic"
         case ThemeIndices.defaultThemeIndex:
             "Default"
+        case ThemeIndices.minimumThemeIndex:
+            "Minimum"
+        case ThemeIndices.technoThemeIndex:
+            "Techno"
         default:
             nil
         }
@@ -109,6 +119,12 @@ public struct ThemeIndexManager: Equatable {
         }
         if index == ThemeIndices.classicDefaultThemeIndex {
             return AzooKeySpecificTheme.default
+        }
+        if index == ThemeIndices.minimumThemeIndex {
+            return AzooKeyTheme.minimum
+        }
+        if index == ThemeIndices.technoThemeIndex {
+            return AzooKeyTheme.techno
         }
         let themeFileURL = Self.fileURL(name: "themes/theme_\(index).theme")
         let data = try Data(contentsOf: themeFileURL)
@@ -197,7 +213,7 @@ public struct ThemeIndexManager: Equatable {
     public var indices: [Int] {
         let indices = index.currentIndices.filter {$0 > 0}.sorted()
         // 負のindexについてはシステム側で並べる
-        return [ThemeIndices.defaultThemeIndex, ThemeIndices.classicDefaultThemeIndex] + indices
+        return [ThemeIndices.defaultThemeIndex, ThemeIndices.classicDefaultThemeIndex, ThemeIndices.technoThemeIndex, ThemeIndices.minimumThemeIndex] + indices
     }
 
     public var selectedIndex: Int {

--- a/AzooKeyCore/Sources/KeyboardThemes/ThemeData.swift
+++ b/AzooKeyCore/Sources/KeyboardThemes/ThemeData.swift
@@ -17,6 +17,7 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
     public var picture: ThemePicture
     public var textColor: ColorData
     public var textFont: ThemeFontWeight
+    public var style: ThemeStyle
     public var resultTextColor: ColorData
     public var resultBackgroundColor: ColorData
     public var borderColor: ColorData
@@ -28,12 +29,13 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
     public var suggestLabelTextColor: ColorData?        // 設定は露出させない
     public var keyShadow: ThemeShadowData<ColorData>?   // 設定は露出させない
 
-    public init(id: Int? = nil, backgroundColor: ColorData, picture: ThemePicture, textColor: ColorData, textFont: ThemeFontWeight, resultTextColor: ColorData, resultBackgroundColor: ColorData, borderColor: ColorData, borderWidth: Double, normalKeyFillColor: ColorData, specialKeyFillColor: ColorData, pushedKeyFillColor: ColorData, suggestKeyFillColor: ColorData? = nil, suggestLabelTextColor: ColorData? = nil, keyShadow: ThemeShadowData<ColorData>? = nil) {
+    public init(id: Int? = nil, backgroundColor: ColorData, picture: ThemePicture, textColor: ColorData, textFont: ThemeFontWeight, style: ThemeStyle = .standard, resultTextColor: ColorData, resultBackgroundColor: ColorData, borderColor: ColorData, borderWidth: Double, normalKeyFillColor: ColorData, specialKeyFillColor: ColorData, pushedKeyFillColor: ColorData, suggestKeyFillColor: ColorData? = nil, suggestLabelTextColor: ColorData? = nil, keyShadow: ThemeShadowData<ColorData>? = nil) {
         self.id = id
         self.backgroundColor = backgroundColor
         self.picture = picture
         self.textColor = textColor
         self.textFont = textFont
+        self.style = style
         self.resultTextColor = resultTextColor
         self.resultBackgroundColor = resultBackgroundColor
         self.borderColor = borderColor
@@ -52,6 +54,7 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
         case picture
         case textColor
         case textFont
+        case style
         case resultTextColor
         case resultBackgroundColor
         case borderColor
@@ -72,6 +75,7 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
         self.picture = try container.decode(ThemePicture.self, forKey: .picture)
         self.textColor = try container.decode(ColorData.self, forKey: .textColor)
         self.textFont = try container.decode(ThemeFontWeight.self, forKey: .textFont)
+        self.style = (try? container.decode(ThemeStyle.self, forKey: .style)) ?? .standard
         self.resultTextColor = try container.decode(ColorData.self, forKey: .resultTextColor)
         self.resultBackgroundColor = (try? container.decode(ColorData.self, forKey: .resultBackgroundColor)) ?? backgroundColor
         self.borderColor = try container.decode(ColorData.self, forKey: .borderColor)
@@ -92,21 +96,51 @@ public struct ThemeData<ApplicationExtension: ApplicationSpecificTheme>: Codable
     }
 
     public var tabBarButtonBackgroundColor: Color {
+        if style == .minimal {
+            return .clear
+        }
+        if style == .faceted {
+            return specialKeyFillColor.color
+        }
         if case .dynamic(.clear, .normal) = self.resultBackgroundColor {
-            .white
+            return .white
         } else {
-            prominentBackgroundColor
+            return prominentBackgroundColor
         }
     }
 
     public var tabBarButtonForegroundColor: Color {
+        if style != .standard {
+            return textColor.color
+        }
         if case .dynamic(.clear, .normal) = self.resultBackgroundColor {
-            Color(red: 0.5, green: 0.043, blue: 0.016)
+            return Color(red: 0.5, green: 0.043, blue: 0.016)
         } else {
-            self.resultTextColor.color
+            return self.resultTextColor.color
         }
     }
 
+    public var tabBarButtonBorderColor: Color {
+        style == .minimal ? specialKeyFillColor.color : borderColor.color
+    }
+
+}
+
+public enum ThemeStyle: String, Codable, Equatable, Sendable {
+    case standard
+    case minimal
+    case faceted
+
+    public var fontDesign: Font.Design {
+        switch self {
+        case .standard:
+            .default
+        case .minimal:
+            .monospaced
+        case .faceted:
+            .serif
+        }
+    }
 }
 
 public struct ThemeShadowData<ColorData>: Codable, Equatable, Sendable where ColorData: Codable & Equatable & Sendable {

--- a/AzooKeyCore/Sources/KeyboardViews/Design.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Design.swift
@@ -255,7 +255,7 @@ public enum Design {
         }
 
         @MainActor func iconImageFont(keyViewFontSizePreference: CGFloat, theme: ThemeData<some ApplicationSpecificTheme>) -> Font {
-            Font.system(size: self.iconFontSize(keyViewFontSizePreference: keyViewFontSizePreference), weight: theme.textFont.weight)
+            Font.system(size: self.iconFontSize(keyViewFontSizePreference: keyViewFontSizePreference), weight: theme.textFont.weight, design: theme.style.fontDesign)
         }
 
         func resultViewFontSize(userPrefrerence: CGFloat) -> CGFloat {
@@ -263,7 +263,7 @@ public enum Design {
         }
 
         func resultViewFont(theme: ThemeData<some ApplicationSpecificTheme>, userSizePrefrerence: CGFloat, fontSize: CGFloat? = nil) -> Font {
-            Font.system(size: fontSize ?? resultViewFontSize(userPrefrerence: userSizePrefrerence)).weight(theme.textFont.weight)
+            Font.system(size: fontSize ?? resultViewFontSize(userPrefrerence: userSizePrefrerence), weight: theme.textFont.weight, design: theme.style.fontDesign)
         }
 
         func forceJapaneseFont(text: String) -> AttributedString {
@@ -331,11 +331,11 @@ public enum Design {
         @MainActor func keyLabelFont(text: String, width: CGFloat, fontSize: LabelFontSizeStrategy, userDecidedSize: CGFloat, theme: ThemeData<some ApplicationSpecificTheme>) -> Font {
             if case .max = fontSize {
                 let size = self.getMaximumFontSize(for: text, width: width, maxFontSize: 100)
-                return Font.system(size: size, weight: theme.textFont.weight, design: .default)
+                return Font.system(size: size, weight: theme.textFont.weight, design: theme.style.fontDesign)
             }
 
             if userDecidedSize != -1 {
-                return .system(size: userDecidedSize * fontSize.scale, weight: theme.textFont.weight, design: .default)
+                return .system(size: userDecidedSize * fontSize.scale, weight: theme.textFont.weight, design: theme.style.fontDesign)
             }
             let maxFontSize = if text.count == 1 {
                 Int(25 * fontSize.scale)
@@ -343,7 +343,7 @@ public enum Design {
                 Int(22 * fontSize.scale)
             }
             let size = self.getMaximumFontSize(for: text, width: width, maxFontSize: maxFontSize)
-            return Font.system(size: size, weight: theme.textFont.weight, design: .default)
+            return Font.system(size: size, weight: theme.textFont.weight, design: theme.style.fontDesign)
         }
     }
 

--- a/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyBackground.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/Components/KeyBackground.swift
@@ -1,21 +1,112 @@
+import KeyboardThemes
 import SwiftUI
 
+private struct FacetedKeyShape: Shape {
+    let cut: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        let value = min(cut, min(rect.width, rect.height) / 3)
+        return Path { path in
+            path.move(to: CGPoint(x: rect.minX + value, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX - value, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY + value))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - value))
+            path.addLine(to: CGPoint(x: rect.maxX - value, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX + value, y: rect.maxY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - value))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + value))
+            path.closeSubpath()
+        }
+    }
+}
+
 struct KeyBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var backgroundColor: Color
     var borderColor: Color
     var borderWidth: CGFloat
     var size: CGSize
     var shadow: (color: Color, radius: CGFloat, x: CGFloat, y: CGFloat)
     var blendMode: BlendMode
+    var appearance: ThemeStyle
+
+    private var surfaceInset: CGFloat {
+        switch appearance {
+        case .standard: 0
+        case .minimal: 5
+        case .faceted: 3
+        }
+    }
+
+    private func surfaceSize(inset: CGFloat) -> CGSize {
+        CGSize(
+            width: max(0, size.width - inset * 2),
+            height: max(0, size.height - inset * 2)
+        )
+    }
+
+    @ViewBuilder
+    private var surface: some View {
+        switch appearance {
+        case .standard:
+            let shape = RoundedRectangle(cornerRadius: 6, style: .continuous)
+            shape
+                .fill(backgroundColor)
+                .overlay {
+                    shape.stroke(borderColor, lineWidth: borderWidth)
+                }
+        case .minimal:
+            let surfaceSize = surfaceSize(inset: 5)
+            Capsule(style: .continuous)
+                .fill(backgroundColor)
+                .frame(
+                    width: max(12, surfaceSize.width * 0.3),
+                    height: max(1.25, borderWidth)
+                )
+                .frame(maxHeight: .infinity, alignment: .bottom)
+                .padding(.bottom, 2)
+        case .faceted:
+            let shape = FacetedKeyShape(cut: 7)
+            shape
+                .fill(backgroundColor)
+                .overlay {
+                    if colorScheme == .dark {
+                        shape.fill(
+                            LinearGradient(
+                                colors: [
+                                    Color.white.opacity(0.09),
+                                    Color.clear,
+                                    Color.black.opacity(0.14),
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                    }
+                }
+                .overlay {
+                    shape.stroke(borderColor, lineWidth: borderWidth)
+                }
+                .overlay {
+                    shape
+                        .stroke(borderColor.opacity(0.22), lineWidth: 0.5)
+                        .padding(2)
+                }
+                .overlay(alignment: .topLeading) {
+                    Capsule(style: .continuous)
+                        .fill(borderColor.opacity(0.9))
+                        .frame(width: 18, height: 1)
+                        .padding(.leading, 11)
+                        .padding(.top, 3)
+                }
+        }
+    }
 
     var body: some View {
-        RoundedRectangle(cornerRadius: 6)
-            .strokeAndFill(
-                fillContent: self.backgroundColor,
-                strokeContent: self.borderColor,
-                lineWidth: self.borderWidth
-            )
-            .frame(width: self.size.width, height: self.size.height)
+        let surfaceSize = surfaceSize(inset: surfaceInset)
+        surface
+            .frame(width: surfaceSize.width, height: surfaceSize.height)
             .compositingGroup()
             .shadow(
                 color: self.shadow.color,
@@ -24,5 +115,7 @@ struct KeyBackground: View {
                 y: self.shadow.y
             )
             .blendMode(self.blendMode)
+            .frame(width: size.width, height: size.height)
+            .contentShape(Rectangle())
     }
 }

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/SimpleKeyView/SimpleKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/SimpleKeyView/SimpleKeyView.swift
@@ -64,7 +64,8 @@ public struct SimpleKeyView<Extension: ApplicationSpecificKeyboardViewExtension>
                         x: theme.keyShadow?.x ?? 0,
                         y: theme.keyShadow?.y ?? 0
                     ),
-                    blendMode: keyBackground.blendMode
+                    blendMode: keyBackground.blendMode,
+                    appearance: theme.style
                 )
             }
             .frame(width: keyViewWidth, height: keyViewHeight)

--- a/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/KeyboardBar/KeyboardBarView.swift
@@ -90,6 +90,7 @@ struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: V
         case systemImage(String)
     }
     @Environment(Extension.Theme.self) private var theme
+    @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var variableStates: VariableStates
     private var action: () -> Void
     private let label: LabelType
@@ -100,7 +101,11 @@ struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: V
     }
 
     private var buttonBackgroundColor: Color {
-        theme.tabBarButtonBackgroundColor
+        if theme.style == .faceted && colorScheme == .light {
+            .white
+        } else {
+            theme.tabBarButtonBackgroundColor
+        }
     }
 
     private var buttonLabelColor: Color {
@@ -125,7 +130,11 @@ struct KeyboardBarButton<Extension: ApplicationSpecificKeyboardViewExtension>: V
         Button(action: self.action) {
             ZStack {
                 Circle()
-                    .strokeAndFill(fillContent: buttonBackgroundColor, strokeContent: theme.borderColor.color, lineWidth: theme.borderWidth)
+                    .strokeAndFill(
+                        fillContent: buttonBackgroundColor,
+                        strokeContent: theme.tabBarButtonBorderColor,
+                        lineWidth: theme.borderWidth
+                    )
                     .frame(width: circleSize, height: circleSize)
                 switch label {
                 case let .azooKeyIcon(looks):

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/Suggest/UnifiedFlickSuggestView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/Suggest/UnifiedFlickSuggestView.swift
@@ -42,7 +42,10 @@ struct UnifiedFlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtensi
         let defaultTheme = Extension.ThemeExtension.default
         let nativeTheme = Extension.ThemeExtension.native
         var pointedColor: Color {
-            switch (colorScheme, theme) {
+            if theme.style == .minimal, let color = theme.suggestKeyFillColor?.color {
+                return color
+            }
+            return switch (colorScheme, theme) {
             case
                 (.dark, defaultTheme):
                 .systemGray4
@@ -53,7 +56,10 @@ struct UnifiedFlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtensi
             }
         }
         var unpointedColor: Color {
-            switch (colorScheme, theme) {
+            if theme.style == .minimal, let color = theme.suggestKeyFillColor?.color {
+                return color
+            }
+            return switch (colorScheme, theme) {
             case
                 (_, defaultTheme),
                 (.dark, nativeTheme):
@@ -126,7 +132,10 @@ struct UnifiedFlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtensi
         let nativeTheme = Extension.ThemeExtension.native
         // ポインテッド時の色を定義
         var color: Color {
-            switch (colorScheme, theme) {
+            if theme.style == .minimal, let color = theme.suggestKeyFillColor?.color {
+                return color
+            }
+            return switch (colorScheme, theme) {
             case (.dark, defaultTheme):
                 .systemGray4
             case (.dark, nativeTheme):
@@ -215,6 +224,11 @@ struct UnifiedFlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtensi
             .frame(width: size.width, height: size.height)
             .allowsHitTesting(false)
         case .flick(let targetDirection):
+            let centerFillColor = if theme.style == .minimal {
+                theme.pushedKeyFillColor
+            } else {
+                theme.specialKeyFillColor
+            }
             VStack(spacing: tabDesign.verticalSpacing) {
                 self.getPointedSuggestViewIfNecessary(direction: .top, targetDirection: targetDirection)
                     .offset(y: size.height / 2)
@@ -225,11 +239,16 @@ struct UnifiedFlickSuggestView<Extension: ApplicationSpecificKeyboardViewExtensi
                         .zIndex(1)
                     RoundedRectangle(cornerRadius: 5.0)
                         .strokeAndFill(
-                            fillContent: theme.specialKeyFillColor.color.blendMode(theme.specialKeyFillColor.blendMode),
+                            fillContent: centerFillColor.color.blendMode(centerFillColor.blendMode),
                             strokeContent: theme.borderColor.color,
                             lineWidth: theme.borderWidth
                         )
                         .frame(width: size.width, height: size.height)
+                        .overlay {
+                            if theme.style == .minimal {
+                                self.model.label(width: size.width, theme: theme, states: variableStates, color: nil)
+                            }
+                        }
                         .zIndex(0)
                     self.getPointedSuggestViewIfNecessary(direction: .right, targetDirection: targetDirection)
                         .offset(x: -size.width / 2)

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/Suggest/UnifiedQwertySuggestView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/Suggest/UnifiedQwertySuggestView.swift
@@ -25,6 +25,9 @@ struct UnifiedQwertySuggestView<Extension: ApplicationSpecificKeyboardViewExtens
     private var keyBorderWidth: CGFloat { theme.borderWidth }
 
     private var suggestColor: Color {
+        if theme.style == .minimal, let color = theme.suggestKeyFillColor?.color {
+            return color
+        }
         let def = Extension.ThemeExtension.default
         let nat = Extension.ThemeExtension.native
         return switch (colorScheme, theme) {

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/UnifiedGenericKeyView.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/UnifiedGenericKeyView.swift
@@ -603,7 +603,8 @@ public struct UnifiedGenericKeyView<Extension: ApplicationSpecificKeyboardViewEx
                 x: theme.keyShadow?.x ?? 0,
                 y: theme.keyShadow?.y ?? 0
             ),
-            blendMode: keyBackgroundStyle.blendMode
+            blendMode: keyBackgroundStyle.blendMode,
+            appearance: theme.style
         )
         .gesture(flickGesture.simultaneously(with: qwertyGesture))
         .overlay { self.model.label(width: size.width, theme: theme, states: variableStates, color: nil) }

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/ThemeManagerTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/ThemeManagerTests.swift
@@ -1,0 +1,71 @@
+@testable import AzooKeyUtils
+import Foundation
+import XCTest
+
+final class ThemeManagerTests: XCTestCase {
+    func testSystemThemesAreIncludedInDisplayOrder() {
+        let manager = ThemeIndexManager(index: ThemeIndices())
+
+        XCTAssertEqual(
+            Array(manager.indices.reversed()),
+            [
+                ThemeIndices.minimumThemeIndex,
+                ThemeIndices.technoThemeIndex,
+                ThemeIndices.classicDefaultThemeIndex,
+                ThemeIndices.defaultThemeIndex,
+            ]
+        )
+    }
+
+    func testSystemThemeIndicesResolveToTheirThemes() throws {
+        let manager = ThemeIndexManager(index: ThemeIndices())
+
+        XCTAssertEqual(
+            try manager.theme(at: ThemeIndices.minimumThemeIndex),
+            .minimum
+        )
+        XCTAssertEqual(
+            try manager.theme(at: ThemeIndices.technoThemeIndex),
+            .techno
+        )
+    }
+
+    func testNewSystemThemesUseTransparentKeyboardBackgrounds() {
+        let themes = [AzooKeyTheme.minimum, .techno]
+
+        for theme in themes {
+            XCTAssertEqual(theme.backgroundColor, .dynamic(.clear))
+            XCTAssertEqual(theme.resultBackgroundColor, .dynamic(.clear))
+        }
+    }
+
+    func testNewSystemThemesHaveDistinctKeyRendering() {
+        XCTAssertEqual(AzooKeyTheme.minimum.style, .minimal)
+
+        XCTAssertEqual(AzooKeyTheme.techno.style, .faceted)
+    }
+
+    func testSavedThemesWithoutStyleUseStandardRendering() throws {
+        var theme = AzooKeyTheme.base
+        theme.id = 1
+        let encodedTheme = try JSONEncoder().encode(theme)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encodedTheme) as? [String: Any]
+        )
+        object.removeValue(forKey: "style")
+        let legacyTheme = try JSONSerialization.data(withJSONObject: object)
+
+        let decodedTheme = try JSONDecoder().decode(AzooKeyTheme.self, from: legacyTheme)
+
+        XCTAssertEqual(decodedTheme.style, .standard)
+    }
+
+    func testSystemThemesCannotBeRemoved() {
+        var manager = ThemeIndexManager(index: ThemeIndices())
+        let originalIndices = manager.indices
+
+        manager.remove(index: ThemeIndices.minimumThemeIndex)
+        manager.remove(index: ThemeIndices.technoThemeIndex)
+        XCTAssertEqual(manager.indices, originalIndices)
+    }
+}


### PR DESCRIPTION
## 概要

新しいシステムテーマ「Minimum」と「Techno」を追加します。既存テーマの配色差分ではなく、キー形状・タイポグラフィ・タブバーボタンを含む専用の描画スタイルとして実装しています。

## 変更内容

- Minimumテーマを追加
  - キー面を省略し、短いアンダーラインとモノスペース書体を組み合わせた表示
  - タブバーボタンを透明背景＋枠線で表示
  - ライト／ダーク双方でサジェストと押下中ラベルの視認性を調整
- Technoテーマを追加
  - 切り欠きのあるキー形状とアクセントラインを使用
  - ライト／ダークで専用配色を適用
  - ライトモードのspecial key、タブバーボタン、ドロップシャドウを調整
- キーボード背景と候補領域の背景はOSのsafe areaと調和する透明表示を維持
- ThemeStyleを追加し、既存の保存済みテーマはstandardへフォールバック
- システムテーマの順序・解決・背景・互換性に関するテストを追加

## 確認内容

- xcodebuild -scheme AzooKeyUtils build-for-testing 成功
- xcodebuild -scheme MainApp build 成功
- SwiftLint確認済み
- git diff --check 成功

## 備考

既存のビルド警告のみで、今回の変更による新規エラーはありません。