### PR TITLE
chore(deps): AzooKeyKanaKanjiConverterを93766c4へ更新

### DIFF
--- a/AzooKeyCore/Package.swift
+++ b/AzooKeyCore/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         // MARK: `_: .upToNextMinor(Version)` or `exact: Version` or `revision: Version`.
         // MARK: For develop branch, you can use `revision:` specification.
         // MARK: For main branch, you must use `upToNextMinor` specification.
-        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "8e3a6eb89e088efd868aa28dadb74c697df4e6fb", traits: ["ZenzaiCPU"]),
+        .package(url: "https://github.com/azooKey/AzooKeyKanaKanjiConverter", revision: "93766c46e31fa6a18b7ced49dab31337780f6f45", traits: ["ZenzaiCPU"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## 概要

AzooKeyKanaKanjiConverterの参照リビジョンを更新します。

## 変更内容

- AzooKeyKanaKanjiConverterを `8e3a6eb89e088efd868aa28dadb74c697df4e6fb` から `93766c46e31fa6a18b7ced49dab31337780f6f45` へ更新
- ZenzaiCPU traitは従来どおり維持

## 動作確認

- `swift package resolve` で指定リビジョンへの依存解決を確認
- `xcodebuild -project azooKey.xcodeproj -scheme MainApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` が成功

なお、`swift test` はmacOS向けビルドでプロジェクト側のUIKit importを解決できないため完走しません。