### PR TITLE
fix(release): v3.1のリリース日を更新

### DIFF
--- a/MainApp/Features/Settings/About/UpdateHistoryView.swift
+++ b/MainApp/Features/Settings/About/UpdateHistoryView.swift
@@ -14,7 +14,7 @@ struct UpdateHistoryView: View {
             // version 3系
             Group {
                 // version 3.1系
-                VersionView("3.1", releaseDate: "近日公開予定") {
+                VersionView("3.1", releaseDate: "2026年08月26日") {
                     if #unavailable(iOS 18) {
                         ParagraphView("お知らせ。") {
                             "バージョン3.2以降でiOS 17のサポートを終了します。iOS 18を最新の状態にアップデートすることで、引き続きご利用いただけます。ご不便をおかけしますが、よろしくお願いいたします"


### PR DESCRIPTION
## 概要

v3.1のリリースに向けて、アプリ内の更新履歴に表示するリリース日を確定しました。

## 変更内容

- v3.1のリリース日を「近日公開予定」から「2026年08月26日」へ変更

## 確認内容

- 対象ファイルのSwiftLint実行（違反0件）
- git diff --check通過