### PR TITLE
fix(keyboard): 長押し候補の展開方向を自動化

### DIFF
--- a/AzooKeyCore/Sources/CustardKit/CustardKit.swift
+++ b/AzooKeyCore/Sources/CustardKit/CustardKit.swift
@@ -662,7 +662,7 @@ public struct CustardInterfaceCustomKey: Codable, Equatable, Hashable, Sendable 
     public var variations: [CustardInterfaceVariation]
 
     /// - direction in which long-press variations expand.
-    ///   `nil` keeps the legacy center-aligned behavior.
+    ///   `nil` automatically selects a direction that minimizes screen overflow.
     public var longpress_variation_direction: CustardInterfaceLongpressVariationDirection?
 
     /// - whether the key shows a QWERTY-style tap bubble.

--- a/AzooKeyCore/Sources/KeyboardViews/Custard/QwertyCustards.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Custard/QwertyCustards.swift
@@ -51,8 +51,7 @@ private enum DefaultQwertyCustards {
         var keys = letterKeys(
             secondRowTrailingKey: inputKey(
                 "ー",
-                variations: ["ー", "。", "、", "！", "？", "・"],
-                direction: .left
+                variations: ["ー", "。", "、", "！", "？", "・"]
             )
         )
         keys[position(0, 2, width: 1.4)] = .system(.qwertyLanguageSwitch)
@@ -77,8 +76,7 @@ private enum DefaultQwertyCustards {
         let secondRowTrailingKey: CustardInterfaceKey? = if shiftKeyPlacement == .bottom {
             inputKey(
                 ".",
-                variations: [".", ",", "!", "?", "'", "\""],
-                direction: .left
+                variations: [".", ",", "!", "?", "'", "\""]
             )
         } else if shiftKeyPlacement == .none {
             .system(.upperLower)
@@ -128,12 +126,7 @@ private enum DefaultQwertyCustards {
         for (index, variations) in numberVariations.enumerated() {
             keys[position(Double(index), 0)] = inputKey(
                 variations[0],
-                variations: variations,
-                direction: variationDirection(
-                    index: index,
-                    rightEdge: 2,
-                    leftEdge: 8
-                )
+                variations: variations
             )
         }
 
@@ -152,8 +145,7 @@ private enum DefaultQwertyCustards {
         for (index, item) in secondRow.enumerated() {
             keys[position(Double(index), 1)] = inputKey(
                 item.0,
-                variations: item.1,
-                direction: index >= 8 ? .left : .center
+                variations: item.1
             )
         }
 
@@ -219,7 +211,6 @@ private enum DefaultQwertyCustards {
             keys[position(Double(index), 0)] = inputKey(
                 item.0,
                 variations: item.1,
-                direction: index == 9 ? .left : .right,
                 showsTapBubble: !item.1.isEmpty
             )
         }
@@ -240,7 +231,6 @@ private enum DefaultQwertyCustards {
             keys[position(Double(index), 1)] = inputKey(
                 item.0,
                 variations: item.1,
-                direction: index == 9 ? .left : .right,
                 showsTapBubble: !item.1.isEmpty
             )
         }
@@ -307,20 +297,14 @@ private enum DefaultQwertyCustards {
     ) -> [CustardKeyPositionSpecifier: CustardInterfaceKey] {
         var keys: [CustardKeyPositionSpecifier: CustardInterfaceKey] = [:]
         for (index, letter) in ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"].enumerated() {
-            keys[position(Double(index), 0)] = inputKey(
-                letter,
-                direction: .right
-            )
+            keys[position(Double(index), 0)] = inputKey(letter)
         }
         if let secondRowLeadingKey {
             keys[position(0, 1)] = secondRowLeadingKey
         }
         let secondRowOffset = secondRowLeadingKey == nil ? 0.0 : 1.0
         for (index, letter) in ["a", "s", "d", "f", "g", "h", "j", "k", "l"].enumerated() {
-            keys[position(secondRowOffset + Double(index), 1)] = inputKey(
-                letter,
-                direction: .right
-            )
+            keys[position(secondRowOffset + Double(index), 1)] = inputKey(letter)
         }
         if let secondRowTrailingKey {
             keys[position(9, 1)] = secondRowTrailingKey
@@ -332,10 +316,7 @@ private enum DefaultQwertyCustards {
         to keys: inout [CustardKeyPositionSpecifier: CustardInterfaceKey]
     ) {
         for (index, letter) in ["z", "x", "c", "v", "b", "n", "m"].enumerated() {
-            keys[position(1.5 + Double(index), 2)] = inputKey(
-                letter,
-                direction: .right
-            )
+            keys[position(1.5 + Double(index), 2)] = inputKey(letter)
         }
         keys[position(8.6, 2, width: 1.4)] = deleteKey
     }
@@ -353,7 +334,6 @@ private enum DefaultQwertyCustards {
     private static func inputKey(
         _ input: String,
         variations: [String] = [],
-        direction: CustardInterfaceLongpressVariationDirection = .center,
         showsTapBubble: Bool = true
     ) -> CustardInterfaceKey {
         .custom(
@@ -371,7 +351,7 @@ private enum DefaultQwertyCustards {
                         )
                     )
                 },
-                longpress_variation_direction: direction,
+                longpress_variation_direction: nil,
                 shows_tap_bubble: showsTapBubble
             )
         )
@@ -397,7 +377,7 @@ private enum DefaultQwertyCustards {
                         )
                     )
                 },
-                longpress_variation_direction: .center,
+                longpress_variation_direction: nil,
                 shows_tap_bubble: !variations.isEmpty
             )
         )
@@ -413,7 +393,7 @@ private enum DefaultQwertyCustards {
                 press_actions: [.moveTab(.system(destination))],
                 longpress_actions: .init(start: [.toggleTabBar]),
                 variations: [],
-                longpress_variation_direction: .right,
+                longpress_variation_direction: nil,
                 shows_tap_bubble: false
             )
         )
@@ -429,24 +409,10 @@ private enum DefaultQwertyCustards {
                 press_actions: [.delete(1)],
                 longpress_actions: .init(repeat: [.delete(1)]),
                 variations: [],
-                longpress_variation_direction: .right,
+                longpress_variation_direction: nil,
                 shows_tap_bubble: false
             )
         )
-    }
-
-    private static func variationDirection(
-        index: Int,
-        rightEdge: Int,
-        leftEdge: Int
-    ) -> CustardInterfaceLongpressVariationDirection {
-        if index < rightEdge {
-            .right
-        } else if index >= leftEdge {
-            .left
-        } else {
-            .center
-        }
     }
 
     private static let legacyNumberMiddleKeys: [QwertyCustomKey] = [

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/CustomKeyboard.swift
@@ -38,6 +38,13 @@ fileprivate extension CustardInterfaceLayoutScrollValue {
 
 public extension CustardInterface {
     @MainActor func unifiedKeyModels<Extension: ApplicationSpecificKeyboardViewExtension>(extension _: Extension.Type) -> [(position: UnifiedPositionSpecifier, model: any UnifiedKeyModelProtocol<Extension>)] {
+        let horizontalKeyCount: CGFloat? = switch self.keyLayout {
+        case let .gridFit(layout):
+            CGFloat(layout.rowCount)
+        case .gridScroll:
+            nil
+        }
+
         func flickTabKeyModel(_ data: KeyFlickSetting.SettingData) -> any UnifiedKeyModelProtocol<Extension> {
             FlickTabKeyModel<Extension>(
                 labelType: data.labelType,
@@ -139,12 +146,22 @@ public extension CustardInterface {
                 }
                 let needSuggest = val.shows_tap_bubble ?? defaultNeedSuggest
                 let linearDirection: VariationsViewDirection = switch val.longpress_variation_direction {
-                case .center, .none:
+                case .center:
                     .center
                 case .right:
                     .right
                 case .left:
                     .left
+                case .none:
+                    if let horizontalKeyCount {
+                        .automatic(
+                            position: pos,
+                            variationCount: linear.count,
+                            horizontalKeyCount: horizontalKeyCount
+                        )
+                    } else {
+                        .center
+                    }
                 }
                 let shouldUppercaseForEnglish: Bool
                 if self.keyStyle == .pcStyle,

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/Suggest/VariationsViewDirection.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/Suggest/VariationsViewDirection.swift
@@ -4,6 +4,50 @@ import SwiftUI
 public enum VariationsViewDirection: Sendable, Equatable {
     case center, right, left
 
+    static func automatic(
+        position: UnifiedPositionSpecifier,
+        variationCount: Int,
+        horizontalKeyCount: CGFloat
+    ) -> Self {
+        guard variationCount > 1, horizontalKeyCount > 0 else {
+            return .center
+        }
+
+        let variationWidth = CGFloat(variationCount)
+        let keyLeading = position.x
+        let keyTrailing = position.x + position.width
+        let keyCenter = (keyLeading + keyTrailing) / 2
+
+        func overflow(leading: CGFloat, trailing: CGFloat) -> CGFloat {
+            max(0, -leading) + max(0, trailing - horizontalKeyCount)
+        }
+
+        let centerOverflow = overflow(
+            leading: keyCenter - variationWidth / 2,
+            trailing: keyCenter + variationWidth / 2
+        )
+        guard centerOverflow > 0 else {
+            return .center
+        }
+
+        let rightOverflow = overflow(
+            leading: keyLeading,
+            trailing: keyLeading + variationWidth
+        )
+        let leftOverflow = overflow(
+            leading: keyTrailing - variationWidth,
+            trailing: keyTrailing
+        )
+
+        if centerOverflow <= min(rightOverflow, leftOverflow) {
+            return .center
+        }
+        if rightOverflow == leftOverflow {
+            return keyCenter <= horizontalKeyCount / 2 ? .right : .left
+        }
+        return rightOverflow < leftOverflow ? .right : .left
+    }
+
     var alignment: Alignment {
         switch self {
         case .center: return .center

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
@@ -234,51 +234,45 @@ final class UserMadeCustardTests: XCTestCase {
         }
     }
 
-    func test_defaultQwertyCustardsPreserveVariationPresentation() throws {
+    func test_defaultQwertyCustardsUseAutomaticVariationDirection() throws {
         let japaneseLetter = try customKey(
             in: .qwertyJapanese,
             at: .init(x: 0, y: 0)
         )
-        XCTAssertEqual(
-            japaneseLetter.longpress_variation_direction,
-            .right
-        )
+        XCTAssertNil(japaneseLetter.longpress_variation_direction)
         XCTAssertEqual(japaneseLetter.shows_tap_bubble, true)
 
         let japaneseBar = try customKey(
             in: .qwertyJapanese,
             at: .init(x: 9, y: 1)
         )
-        XCTAssertEqual(japaneseBar.longpress_variation_direction, .left)
+        XCTAssertNil(japaneseBar.longpress_variation_direction)
         XCTAssertEqual(japaneseBar.shows_tap_bubble, true)
 
         let numberCenter = try customKey(
             in: .qwertyNumbers,
             at: .init(x: 4, y: 0)
         )
-        XCTAssertEqual(numberCenter.longpress_variation_direction, .center)
+        XCTAssertNil(numberCenter.longpress_variation_direction)
         XCTAssertEqual(numberCenter.shows_tap_bubble, true)
 
         let numberRightEdge = try customKey(
             in: .qwertyNumbers,
             at: .init(x: 0, y: 0)
         )
-        XCTAssertEqual(numberRightEdge.longpress_variation_direction, .right)
+        XCTAssertNil(numberRightEdge.longpress_variation_direction)
 
         let numberLeftEdge = try customKey(
             in: .qwertyNumbers,
             at: .init(x: 9, y: 0)
         )
-        XCTAssertEqual(numberLeftEdge.longpress_variation_direction, .left)
+        XCTAssertNil(numberLeftEdge.longpress_variation_direction)
 
         let symbolWithoutVariations = try customKey(
             in: .qwertySymbols,
             at: .init(x: 0, y: 1)
         )
-        XCTAssertEqual(
-            symbolWithoutVariations.longpress_variation_direction,
-            .right
-        )
+        XCTAssertNil(symbolWithoutVariations.longpress_variation_direction)
         XCTAssertEqual(symbolWithoutVariations.shows_tap_bubble, false)
     }
 

--- a/AzooKeyCore/Tests/KeyboardViewsTests/VariationsViewDirectionTests.swift
+++ b/AzooKeyCore/Tests/KeyboardViewsTests/VariationsViewDirectionTests.swift
@@ -1,0 +1,67 @@
+@testable import KeyboardViews
+import XCTest
+
+final class VariationsViewDirectionTests: XCTestCase {
+    func test_automaticUsesRightAtLeadingEdge() {
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 0, y: 0),
+                variationCount: 4,
+                horizontalKeyCount: 10
+            ),
+            .right
+        )
+    }
+
+    func test_automaticUsesLeftAtTrailingEdge() {
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 9, y: 0),
+                variationCount: 4,
+                horizontalKeyCount: 10
+            ),
+            .left
+        )
+    }
+
+    func test_automaticUsesCenterWhenVariationsFit() {
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 4, y: 0),
+                variationCount: 4,
+                horizontalKeyCount: 10
+            ),
+            .center
+        )
+    }
+
+    func test_automaticAccountsForWideKeys() {
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 7.2, y: 0, width: 2.8),
+                variationCount: 6,
+                horizontalKeyCount: 10
+            ),
+            .left
+        )
+    }
+
+    func test_automaticMinimizesOverflowWhenNoDirectionFits() {
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 0, y: 0),
+                variationCount: 12,
+                horizontalKeyCount: 10
+            ),
+            .right
+        )
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 4.5, y: 0),
+                variationCount: 12,
+                horizontalKeyCount: 10
+            ),
+            .center
+        )
+    }
+}


### PR DESCRIPTION
## 概要

長押しバリエーションの展開方向が未指定の場合、キー位置・キー幅・候補数から画面外へのはみ出しが最小になる方向を自動選択するようにします。

カスタムタブでは展開方向を設定するUIがなく、新規キーの方向は未指定になります。従来は未指定を中央展開として扱っていたため、画面端のキーで候補が画面外へ出る場合がありました。

## 変更内容

- longpress_variation_direction が未指定の場合の自動方向判定を追加
  - 中央で収まる場合は中央展開
  - 左右にはみ出す場合は、はみ出しが最小になる方向へ展開
  - どの方向でも収まらない場合も、表示領域が最大になる方向を選択
- 明示された left / center / right は従来どおり優先
- 標準QWERTYの固定方向指定を廃止し、自動判定へ統一
- 左端、右端、中央、幅広キー、候補が画面幅を超える場合のテストを追加

## 確認内容

- MainAppをiOS Simulator向けにビルド
- AzooKeyCoreの全テストターゲットをiOS向けにコンパイル
- 変更ファイルをSwiftLintのstrictモードで確認
