### PR TITLE
fix(custard): 読み込んだ定型文タブを編集可能にする

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
@@ -243,6 +243,41 @@ public struct UserMadeGridFitCustard: Codable, Sendable, Equatable {
 }
 
 public extension Custard {
+    var userMadeGridScrollCustard: UserMadeGridScrollCustard? {
+        guard self.language == .none,
+              self.input_style == .direct,
+              case let .gridScroll(layout) = self.interface.keyLayout else {
+            return nil
+        }
+
+        func countDescription(_ value: Double) -> String {
+            let description = value.description
+            return description.hasSuffix(".0")
+                ? String(description.dropLast(2))
+                : description
+        }
+
+        let keys = self.interface.keys.compactMap { position, key in
+            guard case let .gridScroll(value) = position else {
+                return nil as (index: Int, key: CustardInterfaceKey)?
+            }
+            return (value.index, key)
+        }
+        .sorted { $0.index < $1.index }
+        .map {
+            UserMadeKeyData(model: $0.key, width: 1, height: 1)
+        }
+
+        return UserMadeGridScrollCustard(
+            tabName: self.identifier,
+            direction: layout.direction,
+            columnCount: countDescription(layout.columnCount),
+            rowCount: countDescription(layout.rowCount),
+            keys: keys,
+            addTabBarAutomatically: true
+        )
+    }
+
     var userMadeGridFitCustard: UserMadeGridFitCustard? {
         guard case let .gridFit(layout) = self.interface.keyLayout else {
             return nil

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
@@ -142,6 +142,72 @@ final class UserMadeCustardTests: XCTestCase {
         XCTAssertTrue(editingData.emptyKeys.isEmpty)
     }
 
+    func test_gridScrollCustardCanBeConvertedForEditing() throws {
+        let firstKey = CustardInterfaceKey.custom(
+            .init(
+                design: .init(label: .text("first"), color: .normal),
+                press_actions: [.directInput("first")],
+                longpress_actions: .none,
+                variations: []
+            )
+        )
+        let secondKey = CustardInterfaceKey.system(.enter)
+        let custard = Custard(
+            identifier: "grid-scroll",
+            language: .none,
+            input_style: .direct,
+            metadata: .init(
+                custard_version: .v1_2,
+                display_name: "Grid Scroll"
+            ),
+            interface: .init(
+                keyStyle: .tenkeyStyle,
+                keyLayout: .gridScroll(
+                    .init(
+                        direction: .horizontal,
+                        rowCount: 4,
+                        columnCount: 3
+                    )
+                ),
+                keys: [
+                    .gridScroll(.init(1)): secondKey,
+                    .gridScroll(.init(0)): firstKey,
+                ]
+            )
+        )
+
+        let editingData = try XCTUnwrap(custard.userMadeGridScrollCustard)
+
+        XCTAssertEqual(editingData.tabName, "grid-scroll")
+        XCTAssertEqual(editingData.direction, .horizontal)
+        XCTAssertEqual(editingData.rowCount, "4")
+        XCTAssertEqual(editingData.columnCount, "3")
+        XCTAssertEqual(editingData.keys.map(\.model), [firstKey, secondKey])
+        XCTAssertTrue(editingData.keys.allSatisfy { $0.width == 1 })
+        XCTAssertTrue(editingData.keys.allSatisfy { $0.height == 1 })
+    }
+
+    func test_incompatibleGridScrollCustardCannotBeConvertedForEditing() {
+        let custard = Custard(
+            identifier: "roman-grid-scroll",
+            language: .ja_JP,
+            input_style: .roman2kana,
+            metadata: .init(
+                custard_version: .v1_2,
+                display_name: "Roman Grid Scroll"
+            ),
+            interface: .init(
+                keyStyle: .tenkeyStyle,
+                keyLayout: .gridScroll(
+                    .init(direction: .vertical, rowCount: 4, columnCount: 4)
+                ),
+                keys: [:]
+            )
+        )
+
+        XCTAssertNil(custard.userMadeGridScrollCustard)
+    }
+
     func test_defaultQwertyCustardsCanBeConvertedForEditing() throws {
         let custards: [Custard] = [
             .qwertyJapanese,

--- a/MainApp/Features/Customization/Custard/Management/CustardInformationView.swift
+++ b/MainApp/Features/Customization/Custard/Management/CustardInformationView.swift
@@ -167,6 +167,11 @@ struct CustardInformationView: View {
                         }
                         .foregroundStyle(.accentColor)
                     }
+                } else if let editingItem = custard.userMadeGridScrollCustard {
+                    NavigationLink("編集する") {
+                        EditingScrollCustardView(manager: $keyboardConfiguration.custardManager, editingItem: editingItem, onFinishEditing: onFinishEditing)
+                    }
+                    .foregroundStyle(.accentColor)
                 } else if let editingItem = custard.userMadeGridFitCustard {
                     NavigationLink("編集する") {
                         EditingGridFitCustardView(manager: $keyboardConfiguration.custardManager, editingItem: editingItem, onFinishEditing: onFinishEditing)

--- a/MainApp/Features/Customization/Custard/Management/ManageCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Management/ManageCustardView.swift
@@ -187,6 +187,11 @@ struct ManageCustardView: View {
                                         }
                                     }
                                     Divider()
+                                } else if let editingItem = custard.userMadeGridScrollCustard {
+                                    NavigationLink("編集") {
+                                        EditingScrollCustardView(manager: $manager, editingItem: editingItem, onFinishEditing: onFinishEditing)
+                                    }
+                                    Divider()
                                 } else if let editingItem = custard.userMadeGridFitCustard {
                                     NavigationLink("編集") {
                                         EditingGridFitCustardView(manager: $manager, editingItem: editingItem, onFinishEditing: onFinishEditing)


### PR DESCRIPTION
## 概要

v3.1.0で作成した定型文タブをファイル共有し、azooKeyへ読み込み直した際に「編集する」が表示されない問題を修正します。

## 原因

共有ファイルには実行用のCustardのみが含まれ、編集用のUserMadeCustardデータは含まれていません。読み込んだタブは由来もimportedになるため、Grid Scroll型には既存のGrid Fit型のような編集データ復元処理がなく、編集導線を表示できませんでした。

## 変更内容

- 編集可能なGrid Scroll型CustardからUserMadeGridScrollCustardを復元
- キーをインデックス順に並べて編集データへ変換
- 詳細画面と一覧のコンテキストメニューに編集導線を追加
- 互換形式・非互換形式の変換テストを追加

## 動作確認

- AzooKeyCoreのiOS向けテストターゲットのコンパイル成功
- MainAppのiOS Simulator向けDebugビルド成功
- git diff --check成功
- SwiftLintは今回の変更外にある既存違反2件のみ