### PR TITLE
chore(release): v3.1.1のリリース情報を追加

### DIFF
--- a/MainApp/Features/Settings/About/UpdateHistoryView.swift
+++ b/MainApp/Features/Settings/About/UpdateHistoryView.swift
@@ -14,6 +14,12 @@ struct UpdateHistoryView: View {
             // version 3系
             Group {
                 // version 3.1系
+                VersionView("3.1.1", releaseDate: "2026年08月29日") {
+                    ParagraphView("不具合を修正しました。") {
+                        "キーの長押し候補が画面外に表示されることがある問題を修正しました"
+                        "読み込んだ定型文タブを編集できない問題を修正しました"
+                    }
+                }
                 VersionView("3.1", releaseDate: "2026年08月26日") {
                     if #unavailable(iOS 18) {
                         ParagraphView("お知らせ。") {

--- a/azooKey.xcodeproj/project.pbxproj
+++ b/azooKey.xcodeproj/project.pbxproj
@@ -757,7 +757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1;
+				MARKETING_VERSION = 3.1.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
@@ -792,7 +792,7 @@
 					"@executable_path/Frameworks",
 				);
 				LLVM_LTO = YES_THIN;
-				MARKETING_VERSION = 3.1;
+				MARKETING_VERSION = 3.1.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey;
 				PRODUCT_NAME = azooKey;
@@ -916,7 +916,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.1;
+				MARKETING_VERSION = 3.1.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;
@@ -950,7 +950,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LLVM_LTO = YES_THIN;
-				MARKETING_VERSION = 3.1;
+				MARKETING_VERSION = 3.1.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = DevEn3.azooKey.keyboard;
 				PRODUCT_NAME = Keyboard;


### PR DESCRIPTION
## 概要

azooKeyのマーケティングバージョンを3.1.1へ更新し、アプリ内の更新履歴にv3.1からの変更内容を追加します。

## 変更内容

- MainAppのDebug／Releaseを3.1.1へ更新
- Keyboard ExtensionのDebug／Releaseを3.1.1へ更新
- 2026年8月29日配信としてv3.1.1の更新履歴を追加
  - 長押し候補が画面外に表示される問題の修正
  - 読み込んだ定型文タブを編集できない問題の修正

## 関連PR

- #753
- #754

更新履歴の2件目は#754の修正を前提としているため、v3.1.1のリリースまでに#754をマージする必要があります。

## 動作確認

- MainAppのiOS Simulator向けDebugビルド成功
- UpdateHistoryView.swiftのSwiftLint成功
- project.pbxprojの形式チェック成功
- git diff --check成功