### PR TITLE
fix(custard): 不正なキー構成と保存時の進捗消失を防ぐ

### DIFF
--- a/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
+++ b/AzooKeyCore/Sources/AzooKeyUtils/Custard/UserMadeCustard.swift
@@ -216,6 +216,12 @@ public struct UserMadeGridFitCustard: Codable, Sendable, Equatable {
     public var keyStyle: KeyStyle
     public var addTabBarAutomatically: Bool
 
+    public func canUseKeyStyle(_ keyStyle: KeyStyle) -> Bool {
+        keyStyle == .pcStyle || !self.keys.values.contains {
+            $0.model.isQwertySystemKey
+        }
+    }
+
     private enum CodingKeys: CodingKey {
         case tabName
         case rowCount

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
@@ -32,6 +32,25 @@ final class UserMadeCustardTests: XCTestCase {
         XCTAssertEqual(decoded.keyStyle, .pcStyle)
     }
 
+    func test_gridFitKeyStyleCompatibility() {
+        var custard = makeGridFitCustard(keyStyle: .pcStyle)
+        custard.keys[.gridFit(x: 0, y: 0)] = .init(
+            model: .system(.qwertyShift),
+            width: 1,
+            height: 1
+        )
+
+        XCTAssertTrue(custard.canUseKeyStyle(.pcStyle))
+        XCTAssertFalse(custard.canUseKeyStyle(.tenkeyStyle))
+
+        custard.keys[.gridFit(x: 0, y: 0)] = .init(
+            model: .system(.enter),
+            width: 1,
+            height: 1
+        )
+        XCTAssertTrue(custard.canUseKeyStyle(.tenkeyStyle))
+    }
+
     func test_fractionalGridFitEditingDataRoundTrips() throws {
         var original = makeGridFitCustard(keyStyle: .pcStyle)
         original.keys[.gridFit(x: 1.5, y: 2.3)] = .init(

--- a/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Editing/EditingGridFitCustardView.swift
@@ -82,6 +82,8 @@ struct EditingGridFitCustardView: CancelableEditor {
         var hasShown = false
     }
     @State private var showDuplicateAlert = false
+    @State private var showIncompatibleKeyStyleAlert = false
+    @State private var showSaveErrorAlert = false
 
     private var layout: CustardInterfaceLayoutGridValue {
         .init(rowCount: max(Int(editingItem.rowCount) ?? 1, 1), columnCount: max(Int(editingItem.columnCount) ?? 1, 1))
@@ -116,6 +118,21 @@ struct EditingGridFitCustardView: CancelableEditor {
                 if case let .gridFit(x: x, y: y) = item.key {
                     dict[.gridFit(.init(x: x, y: y, width: item.value.width, height: item.value.height))] = item.value.model
                 }
+            }
+        )
+    }
+
+    private var keyStyle: Binding<UserMadeGridFitCustard.KeyStyle> {
+        Binding(
+            get: {
+                editingItem.keyStyle
+            },
+            set: { newValue in
+                guard editingItem.canUseKeyStyle(newValue) else {
+                    showIncompatibleKeyStyleAlert = true
+                    return
+                }
+                editingItem.keyStyle = newValue
             }
         )
     }
@@ -289,7 +306,7 @@ struct EditingGridFitCustardView: CancelableEditor {
                     Text("そのまま入力").tag(CustardInputStyle.direct)
                     Text("ローマ字かな入力").tag(CustardInputStyle.roman2kana)
                 }
-                Picker("レイアウトスタイル", selection: $editingItem.keyStyle) {
+                Picker("レイアウトスタイル", selection: keyStyle) {
                     Text("フリック").tag(UserMadeGridFitCustard.KeyStyle.tenkeyStyle)
                     Text("QWERTY").tag(UserMadeGridFitCustard.KeyStyle.pcStyle)
                 }
@@ -368,6 +385,12 @@ struct EditingGridFitCustardView: CancelableEditor {
                             }
                             Button("ペーストする", systemImage: "doc.on.clipboard") {
                                 if let copiedKey = self.manager.editorState.copiedKey {
+                                    var candidate = editingItem
+                                    candidate.keys[.gridFit(x: x, y: y)] = copiedKey
+                                    guard candidate.canUseKeyStyle(candidate.keyStyle) else {
+                                        showIncompatibleKeyStyleAlert = true
+                                        return
+                                    }
                                     editingItem.keys[.gridFit(x: x, y: y)] = copiedKey
                                 }
                             }
@@ -428,15 +451,29 @@ struct EditingGridFitCustardView: CancelableEditor {
                     if isNewItem && manager.availableCustards.contains(editingItem.tabName) {
                         showDuplicateAlert = true
                     } else {
-                        self.save()
-                        let saved = custard
-                        finishEditing(identifier: saved.identifier)
+                        do {
+                            let saved = try self.save()
+                            finishEditing(identifier: saved.identifier)
+                        } catch {
+                            debug(error)
+                            showSaveErrorAlert = true
+                        }
                     }
                 }
             }
         }
         .alert("名前が重複しています", isPresented: $showDuplicateAlert) {
             Button("OK", role: .cancel) {}
+        }
+        .alert("QWERTY専用キーとフリックは併用できません", isPresented: $showIncompatibleKeyStyleAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("QWERTY専用キーを使用する場合はレイアウトスタイルをQWERTYにしてください。フリックに変更する場合は、QWERTY専用キーを削除してください。")
+        }
+        .alert("保存できませんでした", isPresented: $showSaveErrorAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("編集内容は保持されています。設定を確認して、もう一度保存してください。")
         }
         .onAppear {
             variableStates.setContainerWidth(
@@ -733,17 +770,15 @@ struct EditingGridFitCustardView: CancelableEditor {
             && data.height == 1
     }
 
-    private func save() {
-        do {
-            try self.manager.saveCustard(
-                custard: custard,
-                metadata: .init(origin: .userMade),
-                userData: .tenkey(editingItem),
-                updateTabBar: self.isNewItem && self.editingItem.addTabBarAutomatically
-            )
-        } catch {
-            debug(error)
-        }
+    private func save() throws -> Custard {
+        let custard = self.custard
+        try self.manager.saveCustard(
+            custard: custard,
+            metadata: .init(origin: .userMade),
+            userData: .tenkey(editingItem),
+            updateTabBar: self.isNewItem && self.editingItem.addTabBarAutomatically
+        )
+        return custard
     }
 
     func cancel() {

--- a/MainApp/Features/Customization/Custard/Editing/EditingScrollCustardView.swift
+++ b/MainApp/Features/Customization/Custard/Editing/EditingScrollCustardView.swift
@@ -57,6 +57,7 @@ struct EditingScrollCustardView: CancelableEditor {
     private let onFinishEditing: ((String) -> Void)?
     @Environment(\.dismiss) var dismiss
     @State private var showDuplicateAlert = false
+    @State private var showSaveErrorAlert = false
 
     init(manager: Binding<CustardManager>, editingItem: UserMadeGridScrollCustard? = nil, onFinishEditing: ((String) -> Void)? = nil) {
         self._manager = manager
@@ -255,15 +256,24 @@ struct EditingScrollCustardView: CancelableEditor {
                     if isNewItem && manager.availableCustards.contains(editingItem.tabName) {
                         showDuplicateAlert = true
                     } else {
-                        self.save()
-                        let saved = makeCustard(data: editingItem)
-                        finishEditing(identifier: saved.identifier)
+                        do {
+                            let saved = try self.save()
+                            finishEditing(identifier: saved.identifier)
+                        } catch {
+                            debug(error)
+                            showSaveErrorAlert = true
+                        }
                     }
                 }
             }
         }
         .alert("名前が重複しています", isPresented: $showDuplicateAlert) {
             Button("OK", role: .cancel) {}
+        }
+        .alert("保存できませんでした", isPresented: $showSaveErrorAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("編集内容は保持されています。設定を確認して、もう一度保存してください。")
         }
     }
 
@@ -288,17 +298,15 @@ struct EditingScrollCustardView: CancelableEditor {
         )
     }
 
-    private func save() {
-        do {
-            try self.manager.saveCustard(
-                custard: makeCustard(data: editingItem),
-                metadata: .init(origin: .userMade),
-                userData: .gridScroll(editingItem),
-                updateTabBar: self.isNewItem && self.editingItem.addTabBarAutomatically
-            )
-        } catch {
-            debug(error)
-        }
+    private func save() throws -> Custard {
+        let custard = makeCustard(data: editingItem)
+        try self.manager.saveCustard(
+            custard: custard,
+            metadata: .init(origin: .userMade),
+            userData: .gridScroll(editingItem),
+            updateTabBar: self.isNewItem && self.editingItem.addTabBarAutomatically
+        )
+        return custard
     }
 
     func cancel() {


### PR DESCRIPTION
## 概要

カスタムタブ作成中にQWERTY専用キーを配置し、レイアウトスタイルをフリックへ変更すると、保存されないまま編集画面が閉じて進捗が失われる問題を修正します。

## 原因

QWERTY専用キーとtenkeyStyleの組み合わせはCustardKitのバリデーションで拒否されますが、エディタ上ではこの組み合わせを作成できました。また、保存処理がエラーを内部で握りつぶし、その後も保存成功時の画面遷移を実行していました。

新規作成時には存在しないタブの詳細画面へ遷移するため、空の画面が表示されていました。

## 変更内容

- QWERTY専用キーが存在する場合、レイアウトスタイルをフリックへ変更できないように修正
- コピーしたQWERTY専用キーをフリックタブへ貼り付ける経路も防止
- 不正な組み合わせを操作した場合に理由をアラートで表示
- Grid Fit／Grid Scrollの両エディタで、保存成功時だけ編集画面を閉じるように修正
- 保存失敗時は編集内容を保持し、エラーをアラートで表示
- キースタイル互換判定の回帰テストを追加

## 動作確認

- MainAppのiOS Simulator向けDebugビルド成功
- AzooKeyCoreのiOS向けテストターゲットのコンパイル成功
- 変更ファイルのSwiftLint成功
- git diff --check成功

追加したテストのSimulator実行は、Simulatorサービスへ接続できない環境エラーにより中断しました。