### PR TITLE
fix(keyboard): 長押し候補を常に自動調整する

### DIFF
--- a/AzooKeyCore/Sources/CustardKit/CustardKit.swift
+++ b/AzooKeyCore/Sources/CustardKit/CustardKit.swift
@@ -624,13 +624,6 @@ public extension CustardInterfaceSystemKey {
     }
 }
 
-/// - direction in which long-press variations expand
-public enum CustardInterfaceLongpressVariationDirection: String, Codable, Equatable, Hashable, Sendable {
-    case center
-    case right
-    case left
-}
-
 /// - keys you can defined
 public struct CustardInterfaceCustomKey: Codable, Equatable, Hashable, Sendable {
     public init(
@@ -638,14 +631,12 @@ public struct CustardInterfaceCustomKey: Codable, Equatable, Hashable, Sendable 
         press_actions: [CodableActionData],
         longpress_actions: CodableLongpressActionData,
         variations: [CustardInterfaceVariation],
-        longpress_variation_direction: CustardInterfaceLongpressVariationDirection? = nil,
         shows_tap_bubble: Bool? = nil
     ) {
         self.design = design
         self.press_actions = press_actions
         self.longpress_actions = longpress_actions
         self.variations = variations
-        self.longpress_variation_direction = longpress_variation_direction
         self.shows_tap_bubble = shows_tap_bubble
     }
 
@@ -660,10 +651,6 @@ public struct CustardInterfaceCustomKey: Codable, Equatable, Hashable, Sendable 
 
     /// - variations available when user flick or longpress this key
     public var variations: [CustardInterfaceVariation]
-
-    /// - direction in which long-press variations expand.
-    ///   `nil` automatically selects a direction that minimizes screen overflow.
-    public var longpress_variation_direction: CustardInterfaceLongpressVariationDirection?
 
     /// - whether the key shows a QWERTY-style tap bubble.
     ///   `nil` keeps the legacy behavior inferred from the key style and actions.

--- a/AzooKeyCore/Sources/KeyboardViews/Custard/QwertyCustards.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Custard/QwertyCustards.swift
@@ -351,7 +351,6 @@ private enum DefaultQwertyCustards {
                         )
                     )
                 },
-                longpress_variation_direction: nil,
                 shows_tap_bubble: showsTapBubble
             )
         )
@@ -377,7 +376,6 @@ private enum DefaultQwertyCustards {
                         )
                     )
                 },
-                longpress_variation_direction: nil,
                 shows_tap_bubble: !variations.isEmpty
             )
         )
@@ -393,7 +391,6 @@ private enum DefaultQwertyCustards {
                 press_actions: [.moveTab(.system(destination))],
                 longpress_actions: .init(start: [.toggleTabBar]),
                 variations: [],
-                longpress_variation_direction: nil,
                 shows_tap_bubble: false
             )
         )
@@ -409,7 +406,6 @@ private enum DefaultQwertyCustards {
                 press_actions: [.delete(1)],
                 longpress_actions: .init(repeat: [.delete(1)]),
                 variations: [],
-                longpress_variation_direction: nil,
                 shows_tap_bubble: false
             )
         )

--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/CustomKeyboard.swift
@@ -145,23 +145,14 @@ public extension CustardInterface {
                     val.longpress_actions.isEmpty
                 }
                 let needSuggest = val.shows_tap_bubble ?? defaultNeedSuggest
-                let linearDirection: VariationsViewDirection = switch val.longpress_variation_direction {
-                case .center:
+                let linearDirection: VariationsViewDirection = if let horizontalKeyCount {
+                    .automatic(
+                        position: pos,
+                        variationCount: linear.count,
+                        horizontalKeyCount: horizontalKeyCount
+                    )
+                } else {
                     .center
-                case .right:
-                    .right
-                case .left:
-                    .left
-                case .none:
-                    if let horizontalKeyCount {
-                        .automatic(
-                            position: pos,
-                            variationCount: linear.count,
-                            horizontalKeyCount: horizontalKeyCount
-                        )
-                    } else {
-                        .center
-                    }
                 }
                 let shouldUppercaseForEnglish: Bool
                 if self.keyStyle == .pcStyle,

--- a/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
+++ b/AzooKeyCore/Tests/AzooKeyUtilsTests/UserMadeCustardTests.swift
@@ -319,45 +319,29 @@ final class UserMadeCustardTests: XCTestCase {
         }
     }
 
-    func test_defaultQwertyCustardsUseAutomaticVariationDirection() throws {
+    func test_defaultQwertyCustardsPreserveTapBubblePresentation() throws {
         let japaneseLetter = try customKey(
             in: .qwertyJapanese,
             at: .init(x: 0, y: 0)
         )
-        XCTAssertNil(japaneseLetter.longpress_variation_direction)
         XCTAssertEqual(japaneseLetter.shows_tap_bubble, true)
 
         let japaneseBar = try customKey(
             in: .qwertyJapanese,
             at: .init(x: 9, y: 1)
         )
-        XCTAssertNil(japaneseBar.longpress_variation_direction)
         XCTAssertEqual(japaneseBar.shows_tap_bubble, true)
 
         let numberCenter = try customKey(
             in: .qwertyNumbers,
             at: .init(x: 4, y: 0)
         )
-        XCTAssertNil(numberCenter.longpress_variation_direction)
         XCTAssertEqual(numberCenter.shows_tap_bubble, true)
-
-        let numberRightEdge = try customKey(
-            in: .qwertyNumbers,
-            at: .init(x: 0, y: 0)
-        )
-        XCTAssertNil(numberRightEdge.longpress_variation_direction)
-
-        let numberLeftEdge = try customKey(
-            in: .qwertyNumbers,
-            at: .init(x: 9, y: 0)
-        )
-        XCTAssertNil(numberLeftEdge.longpress_variation_direction)
 
         let symbolWithoutVariations = try customKey(
             in: .qwertySymbols,
             at: .init(x: 0, y: 1)
         )
-        XCTAssertNil(symbolWithoutVariations.longpress_variation_direction)
         XCTAssertEqual(symbolWithoutVariations.shows_tap_bubble, false)
     }
 

--- a/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceCustomKeyTest.swift
+++ b/AzooKeyCore/Tests/CustardKitTests/CustardInterfaceCustomKeyTest.swift
@@ -1,4 +1,5 @@
 @testable import CustardKit
+import Foundation
 import XCTest
 
 final class CustardInterfaceCustomKeyTest: XCTestCase {
@@ -34,8 +35,11 @@ final class CustardInterfaceCustomKeyTest: XCTestCase {
                 )
             )
         }
-        do {
-            let target = """
+    }
+
+    func testDecodeIgnoresLegacyLongpressVariationDirection() throws {
+        let data = Data(
+            """
             {
                 "design": {"label":{"text": "A"}, "color": "normal"},
                 "press_actions": [{
@@ -50,19 +54,29 @@ final class CustardInterfaceCustomKeyTest: XCTestCase {
                 "longpress_variation_direction": "right",
                 "shows_tap_bubble": true
             }
-            """
-            XCTAssertEqual(
-                CustardInterfaceCustomKey.quickDecode(target: target),
-                .init(
-                    design: .init(label: .text("A"), color: .normal),
-                    press_actions: [.input("a")],
-                    longpress_actions: .none,
-                    variations: [],
-                    longpress_variation_direction: .right,
-                    shows_tap_bubble: true
-                )
+            """.utf8
+        )
+        let decoded = try JSONDecoder().decode(
+            CustardInterfaceCustomKey.self,
+            from: data
+        )
+
+        XCTAssertEqual(
+            decoded,
+            .init(
+                design: .init(label: .text("A"), color: .normal),
+                press_actions: [.input("a")],
+                longpress_actions: .none,
+                variations: [],
+                shows_tap_bubble: true
             )
-        }
+        )
+
+        let encoded = try JSONEncoder().encode(decoded)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        XCTAssertNil(object["longpress_variation_direction"])
     }
 
     func testEncode() {
@@ -80,7 +94,6 @@ final class CustardInterfaceCustomKeyTest: XCTestCase {
                 press_actions: [.input("=")],
                 longpress_actions: .none,
                 variations: [],
-                longpress_variation_direction: .left,
                 shows_tap_bubble: false
             )
             XCTAssertEqual(target.quickEncodeDecode(), target)

--- a/AzooKeyCore/Tests/KeyboardViewsTests/VariationsViewDirectionTests.swift
+++ b/AzooKeyCore/Tests/KeyboardViewsTests/VariationsViewDirectionTests.swift
@@ -24,6 +24,17 @@ final class VariationsViewDirectionTests: XCTestCase {
         )
     }
 
+    func test_automaticCentersThreeVariationsAtSampleKeyPosition() {
+        XCTAssertEqual(
+            VariationsViewDirection.automatic(
+                position: .init(x: 8, y: 0),
+                variationCount: 3,
+                horizontalKeyCount: 10
+            ),
+            .center
+        )
+    }
+
     func test_automaticUsesCenterWhenVariationsFit() {
         XCTAssertEqual(
             VariationsViewDirection.automatic(


### PR DESCRIPTION
## 概要
カスタムタブの明示的な長押し候補展開方向を廃止し、キー位置と候補数に基づいて常に自動調整するようにします。v3.1で作成されたタブなどに残る right 指定により、候補が画面外へ出る問題を防ぎます。

## 原因
提供された sample.json では、カスタムキーに longpress_variation_direction: right が保存されていました。キリル文字の「о」（x: 8、候補数: 3、横キー数: 10）でも明示指定が自動判定より優先され、右方向へ展開されていました。

## 変更内容
- 長押し候補の方向指定用enum・プロパティ・初期化引数を削除
- Grid Fitレイアウトでは長押し候補の方向を常に自動判定
- 旧JSON内の longpress_variation_direction は未知フィールドとして無視し、再書き出し時には出力しない
- 旧JSONの読み込み互換性と再書き出しをテスト
- sample.json相当の位置（x: 8、候補数: 3、横キー数: 10）が中央展開になる回帰テストを追加
- 標準QWERTY定義と関連テストから不要な方向指定を削除

## 互換性
旧形式のJSONは引き続き読み込めます。保存済みの方向指定は動作に影響せず、再書き出し時に削除されます。公開されていた CustardInterfaceLongpressVariationDirection と対応する初期化引数は、機能廃止に伴い削除しています。

## 動作確認
- MainApp（iOS Simulator向けDebug）ビルド成功
- AzooKeyCoreのiOSテストターゲットを含むビルド成功
- 変更6ファイルのSwiftLint成功（0 violations）
- git diff --check成功

なお、個別テストのSimulator実行は、ローカルに残っていたSimulator端末データが見つからず起動できなかったため未実施です。テストターゲットのコンパイルは完了しています。