### PR TITLE
fix(keyboard): 10キー超のspacing比率を固定する

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/Design.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Design.swift
@@ -21,6 +21,12 @@ public struct TabDependentDesign {
     private var interfaceWidth: CGFloat
     private var interfaceHeight: CGFloat
 
+    /// Keep the total key and spacing ratios at the standard QWERTY layout once
+    /// the layout has more than ten horizontal keys.
+    private var horizontalKeyCountForSizing: CGFloat {
+        min(horizontalKeyCount, 10)
+    }
+
     public init(
         width: Int,
         height: Int,
@@ -51,12 +57,13 @@ public struct TabDependentDesign {
 
     /// screenWidthとhorizontalKeyCountに依存
     var keyViewWidth: CGFloat {
+        let horizontalKeyCountForSizing = self.horizontalKeyCountForSizing
         let coefficient: CGFloat
         switch orientation {
         case .vertical:
-            coefficient = 5 / (5.1 + horizontalKeyCount / 10)
+            coefficient = 5 / (5.1 + horizontalKeyCountForSizing / 10)
         case .horizontal:
-            coefficient = 10 / (10.2 + horizontalKeyCount * 0.28)
+            coefficient = 10 / (10.2 + horizontalKeyCountForSizing * 0.28)
         }
         return interfaceWidth / horizontalKeyCount * coefficient
     }
@@ -95,12 +102,13 @@ public struct TabDependentDesign {
         if horizontalKeyCount <= 1 {
             return 0
         }
+        let horizontalKeyCountForSizing = self.horizontalKeyCountForSizing
         let coefficient: CGFloat
         switch orientation {
         case .vertical:
-            coefficient = (5 + horizontalKeyCount) / (7.5 + horizontalKeyCount)
+            coefficient = (5 + horizontalKeyCountForSizing) / (7.5 + horizontalKeyCountForSizing)
         case .horizontal:
-            coefficient = (8 + horizontalKeyCount) / (10 + horizontalKeyCount * 1.3)
+            coefficient = (8 + horizontalKeyCountForSizing) / (10 + horizontalKeyCountForSizing * 1.3)
         }
         return (interfaceWidth - keyViewWidth * horizontalKeyCount) / (horizontalKeyCount - 1) * coefficient
     }

--- a/AzooKeyCore/Tests/KeyboardViewsTests/TabDependentDesignTests.swift
+++ b/AzooKeyCore/Tests/KeyboardViewsTests/TabDependentDesignTests.swift
@@ -1,0 +1,55 @@
+@testable import KeyboardViews
+import XCTest
+
+final class TabDependentDesignTests: XCTestCase {
+    private let interfaceSize = CGSize(width: 1_000, height: 300)
+
+    private func design(horizontalKeyCount: CGFloat, orientation: KeyboardOrientation) -> TabDependentDesign {
+        TabDependentDesign(
+            width: horizontalKeyCount,
+            height: 4,
+            interfaceSize: interfaceSize,
+            layoutContext: KeyboardLayoutContext(
+                containerWidth: interfaceSize.width,
+                orientation: orientation,
+                idiom: .phone
+            )
+        )
+    }
+
+    func test_horizontalSizingKeepsTenKeyRatiosForLargerLayouts() {
+        for orientation in [KeyboardOrientation.vertical, .horizontal] {
+            let tenKeyDesign = design(horizontalKeyCount: 10, orientation: orientation)
+            let twentyKeyDesign = design(horizontalKeyCount: 20, orientation: orientation)
+
+            XCTAssertEqual(
+                tenKeyDesign.keyViewWidth * 10,
+                twentyKeyDesign.keyViewWidth * 20,
+                accuracy: 0.001
+            )
+            XCTAssertEqual(
+                tenKeyDesign.horizontalSpacing * 9,
+                twentyKeyDesign.horizontalSpacing * 19,
+                accuracy: 0.001
+            )
+            XCTAssertEqual(tenKeyDesign.keysWidth, twentyKeyDesign.keysWidth, accuracy: 0.001)
+        }
+    }
+
+    func test_horizontalSizingPreservesExistingFormulaBelowTenKeys() {
+        let verticalDesign = design(horizontalKeyCount: 5, orientation: .vertical)
+        let horizontalDesign = design(horizontalKeyCount: 5, orientation: .horizontal)
+        let keyCount: CGFloat = 5
+        let verticalKeyWidth = interfaceSize.width / keyCount * (5 / (5.1 + keyCount / 10))
+        let verticalSpacing = (interfaceSize.width - verticalKeyWidth * keyCount) / (keyCount - 1)
+            * ((5 + keyCount) / (7.5 + keyCount))
+        let horizontalKeyWidth = interfaceSize.width / keyCount * (10 / (10.2 + keyCount * 0.28))
+        let horizontalSpacing = (interfaceSize.width - horizontalKeyWidth * keyCount) / (keyCount - 1)
+            * ((8 + keyCount) / (10 + keyCount * 1.3))
+
+        XCTAssertEqual(verticalDesign.keyViewWidth, verticalKeyWidth, accuracy: 0.001)
+        XCTAssertEqual(verticalDesign.horizontalSpacing, verticalSpacing, accuracy: 0.001)
+        XCTAssertEqual(horizontalDesign.keyViewWidth, horizontalKeyWidth, accuracy: 0.001)
+        XCTAssertEqual(horizontalDesign.horizontalSpacing, horizontalSpacing, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## 概要
横方向のキー数が10を超えるレイアウトで、spacing全体がキーボード幅に占める割合を10キー時点に固定します。増えたキー数に応じて、キー幅とspacingをそれぞれ再配分します。

## 背景
従来の計算では、横方向のキー数を増やすほどキー幅の合計割合が減り、spacingの合計割合が増えていました。そのため、キー数の多いカスタムタブではキーに対して隙間が相対的に大きくなっていました。

## 変更内容
- 係数計算に使う横キー数を最大10に制限
- 実際のキー幅は本来のキー数 n で分配
- 実際のspacingは隙間数 n - 1 で分配
- 10キー以下の既存レイアウトは従来の計算結果を維持
- 10キー超では、10キー時点の以下の比率を維持
  - キー幅の合計
  - spacingの合計
  - レイアウト全体の使用幅

## テスト
- 縦画面・横画面の両方で、10キーと20キーの合計比率が一致することを確認
- 10キー未満では従来の計算式が維持されることを確認

## 動作確認
- AzooKeyCoreのiOSテストターゲットを含むビルド成功
- MainAppのiOS Simulator向けDebugビルド成功
- SwiftLint成功（0 violations）
- git diff --check成功