### PR TITLE
fix(keyboard): 縦spacingを4キー相当に抑える

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/Design.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/Design.swift
@@ -89,12 +89,16 @@ public struct TabDependentDesign {
     }
 
     var verticalSpacing: CGFloat {
-        switch orientation {
+        let spacing = switch orientation {
         case .vertical:
-            return interfaceWidth / 50
+            interfaceWidth / 50
         case .horizontal:
-            return interfaceWidth / 107
+            interfaceWidth / 107
         }
+        guard verticalKeyCount > 4 else {
+            return spacing
+        }
+        return spacing * 3 / (verticalKeyCount - 1)
     }
 
     /// screenWidthとhorizontalKeyCountとkeyViewWidthに依存

--- a/AzooKeyCore/Tests/KeyboardViewsTests/TabDependentDesignTests.swift
+++ b/AzooKeyCore/Tests/KeyboardViewsTests/TabDependentDesignTests.swift
@@ -4,10 +4,14 @@ import XCTest
 final class TabDependentDesignTests: XCTestCase {
     private let interfaceSize = CGSize(width: 1_000, height: 300)
 
-    private func design(horizontalKeyCount: CGFloat, orientation: KeyboardOrientation) -> TabDependentDesign {
+    private func design(
+        horizontalKeyCount: CGFloat = 10,
+        verticalKeyCount: CGFloat = 4,
+        orientation: KeyboardOrientation
+    ) -> TabDependentDesign {
         TabDependentDesign(
             width: horizontalKeyCount,
-            height: 4,
+            height: verticalKeyCount,
             interfaceSize: interfaceSize,
             layoutContext: KeyboardLayoutContext(
                 containerWidth: interfaceSize.width,
@@ -51,5 +55,31 @@ final class TabDependentDesignTests: XCTestCase {
         XCTAssertEqual(verticalDesign.horizontalSpacing, verticalSpacing, accuracy: 0.001)
         XCTAssertEqual(horizontalDesign.keyViewWidth, horizontalKeyWidth, accuracy: 0.001)
         XCTAssertEqual(horizontalDesign.horizontalSpacing, horizontalSpacing, accuracy: 0.001)
+    }
+
+    @MainActor func test_verticalSizingKeepsFourKeyRatiosForLargerLayouts() {
+        for orientation in [KeyboardOrientation.vertical, .horizontal] {
+            let fourKeyDesign = design(verticalKeyCount: 4, orientation: orientation)
+            let eightKeyDesign = design(verticalKeyCount: 8, orientation: orientation)
+
+            XCTAssertEqual(
+                fourKeyDesign.keyViewHeight * 4,
+                eightKeyDesign.keyViewHeight * 8,
+                accuracy: 0.001
+            )
+            XCTAssertEqual(
+                fourKeyDesign.verticalSpacing * 3,
+                eightKeyDesign.verticalSpacing * 7,
+                accuracy: 0.001
+            )
+        }
+    }
+
+    func test_verticalSpacingPreservesExistingFormulaUpToFourKeys() {
+        let verticalDesign = design(verticalKeyCount: 3, orientation: .vertical)
+        let horizontalDesign = design(verticalKeyCount: 3, orientation: .horizontal)
+
+        XCTAssertEqual(verticalDesign.verticalSpacing, interfaceSize.width / 50, accuracy: 0.001)
+        XCTAssertEqual(horizontalDesign.verticalSpacing, interfaceSize.width / 107, accuracy: 0.001)
     }
 }


### PR DESCRIPTION
## 概要
縦方向のキー数が4を超えるレイアウトで、縦spacingの合計を4キー時点の量に固定します。キー数の増加に応じてspacingを再分配し、減少したspacing分をキー高さへ戻します。

## 背景
従来の縦spacingはキー数に関係なく1つ当たりの値が固定されていました。そのため、縦キー数を増やすほどspacingの合計が増え、キー高さを圧迫していました。

## 変更内容
- 縦キー数が4以下の場合は従来のspacingを維持
- 縦キー数が4を超える場合は、4キー時点の3隙間分を n - 1 個へ再分配
- 減少したspacing分は既存のキー高さ計算によってキーへ再配分
- 縦画面・横画面の両方に同じ上限制御を適用

## 計算式
従来の縦spacingを S、縦キー数を n とすると、n > 4 では次の値を使用します。

    verticalSpacing = 3S / (n - 1)

これにより、縦spacingの合計は常に3Sが上限になります。

## テスト
- 4キーと8キーでキー高さの合計が一致することを確認
- 4キーと8キーで縦spacingの合計が一致することを確認
- 4キー未満では従来の計算式が維持されることを確認
- 縦画面・横画面の両方を検証

## 動作確認
- AzooKeyCoreのiOSテストターゲットを含むビルド成功
- MainAppのiOS Simulator向けDebugビルド成功
- SwiftLint成功（0 violations）
- git diff --check成功