### PR TITLE
fix(keyboard): 複合ラベルをShift表示に追従させる

### DIFF
--- a/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/CustomKeyboard.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/CustomKeyboard/CustomKeyboard.swift
@@ -154,17 +154,6 @@ public extension CustardInterface {
                 } else {
                     .center
                 }
-                let shouldUppercaseForEnglish: Bool
-                if self.keyStyle == .pcStyle,
-                   case let .text(label) = val.design.label,
-                   label.count == 1,
-                   val.press_actions.count == 1,
-                   case let .input(input) = val.press_actions[0],
-                   label == input {
-                    shouldUppercaseForEnglish = true
-                } else {
-                    shouldUppercaseForEnglish = false
-                }
                 let model = UnifiedGeneralKeyModel<Extension>(
                     labelType: val.design.label.keyLabelType,
                     pressActions: val.press_actions.map { $0.actionType },
@@ -174,7 +163,7 @@ public extension CustardInterface {
                     linearDirection: linearDirection,
                     showsTapBubble: needSuggest,
                     colorRole: colorRole,
-                    shouldUppercaseForEnglish: shouldUppercaseForEnglish
+                    shouldUppercaseForEnglish: self.keyStyle == .pcStyle
                 )
                 models.append((pos, model))
             }

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/KeyLabelType+Uppercase.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/KeyLabelType+Uppercase.swift
@@ -1,0 +1,53 @@
+import CustardKit
+import Foundation
+
+extension KeyLabelType {
+    func uppercasedForEnglishIfInputMatches(
+        pressActions: [ActionType],
+        flickMap: [FlickDirection: UnifiedVariation] = [:]
+    ) -> Self {
+        switch self {
+        case let .text(text):
+            return .text(text.uppercasedIfInputMatches(pressActions))
+        case let .symbols(symbols):
+            guard let main = symbols.first else {
+                return self
+            }
+            return .symbols([main.uppercasedIfInputMatches(pressActions)] + symbols.dropFirst())
+        case let .mainAndDirections(main, directions):
+            return .mainAndDirections(
+                main.uppercasedIfInputMatches(pressActions),
+                CustardKeyDirectionalLabel(
+                    left: directions.left?.uppercasedIfInputMatches(flickMap[.left]?.pressActions ?? []),
+                    top: directions.top?.uppercasedIfInputMatches(flickMap[.top]?.pressActions ?? []),
+                    right: directions.right?.uppercasedIfInputMatches(flickMap[.right]?.pressActions ?? []),
+                    bottom: directions.bottom?.uppercasedIfInputMatches(flickMap[.bottom]?.pressActions ?? [])
+                )
+            )
+        case .image, .customImage, .changeKeyboard, .selectable:
+            return self
+        }
+    }
+}
+
+extension UnifiedVariation {
+    func uppercasedForEnglishIfInputMatches() -> Self {
+        UnifiedVariation(
+            label: label.uppercasedForEnglishIfInputMatches(pressActions: pressActions),
+            pressActions: pressActions,
+            longPressActions: longPressActions
+        )
+    }
+}
+
+private extension String {
+    func uppercasedIfInputMatches(_ actions: [ActionType]) -> Self {
+        guard count == 1,
+              actions.count == 1,
+              case let .input(input, _) = actions[0],
+              self == input else {
+            return self
+        }
+        return uppercased()
+    }
+}

--- a/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/KeyModels/UnifiedGeneralKeyModel.swift
+++ b/AzooKeyCore/Sources/KeyboardViews/View/UnifiedKey/KeyModels/UnifiedGeneralKeyModel.swift
@@ -69,21 +69,33 @@ struct UnifiedGeneralKeyModel<Extension: ApplicationSpecificKeyboardViewExtensio
         flickMap.keys.contains(direction)
     }
 
-    @MainActor func getFlickVariationMap(variableStates _: VariableStates) -> [FlickDirection: UnifiedVariation] {
-        flickMap
+    @MainActor func getFlickVariationMap(variableStates: VariableStates) -> [FlickDirection: UnifiedVariation] {
+        guard usesUppercaseLabel(states: variableStates) else {
+            return flickMap
+        }
+        return flickMap.mapValues { $0.uppercasedForEnglishIfInputMatches() }
     }
     @MainActor func getLinearVariations(variableStates _: VariableStates) ->
     (arr: [QwertyVariationsModel.VariationElement], direction: VariationsViewDirection) { (linearVariations, linearDirection)
     }
 
     func label<ThemeExtension>(width: CGFloat, theme _: ThemeData<ThemeExtension>, states: VariableStates, color _: Color?) -> KeyLabel<Extension> where ThemeExtension: ApplicationSpecificKeyboardViewExtensionLayoutDependentDefaultThemeProvidable {
-        if shouldUppercaseForEnglish,
-           states.boolStates.isCapsLocked || states.boolStates.isShifted,
-           states.keyboardLanguage == .en_US,
-           case let .text(text) = labelType {
-            return KeyLabel(.text(text.uppercased()), width: width)
+        if usesUppercaseLabel(states: states) {
+            return KeyLabel(
+                labelType.uppercasedForEnglishIfInputMatches(
+                    pressActions: centerPress,
+                    flickMap: flickMap
+                ),
+                width: width
+            )
         }
         return KeyLabel(labelType, width: width)
+    }
+
+    private func usesUppercaseLabel(states: VariableStates) -> Bool {
+        shouldUppercaseForEnglish
+            && (states.boolStates.isCapsLocked || states.boolStates.isShifted)
+            && states.keyboardLanguage == .en_US
     }
 
     @MainActor

--- a/AzooKeyCore/Tests/KeyboardViewsTests/KeyLabelTypeUppercaseTests.swift
+++ b/AzooKeyCore/Tests/KeyboardViewsTests/KeyLabelTypeUppercaseTests.swift
@@ -1,0 +1,63 @@
+import CustardKit
+@testable import KeyboardViews
+import XCTest
+
+final class KeyLabelTypeUppercaseTests: XCTestCase {
+    func test_textUppercasesOnlyWhenSingleInputMatches() {
+        XCTAssertEqual(
+            KeyLabelType.text("a").uppercasedForEnglishIfInputMatches(pressActions: [.input("a")]),
+            .text("A")
+        )
+        XCTAssertEqual(
+            KeyLabelType.text("a").uppercasedForEnglishIfInputMatches(pressActions: [.input("b")]),
+            .text("a")
+        )
+        XCTAssertEqual(
+            KeyLabelType.text("a").uppercasedForEnglishIfInputMatches(
+                pressActions: [.input("a"), .moveCursor(1)]
+            ),
+            .text("a")
+        )
+    }
+
+    func test_mainAndSubUppercasesOnlyMainLabel() {
+        XCTAssertEqual(
+            KeyLabelType.symbols(["a", "abc"])
+                .uppercasedForEnglishIfInputMatches(pressActions: [.input("a")]),
+            .symbols(["A", "abc"])
+        )
+    }
+
+    func test_mainAndDirectionsUppercasesOnlyLabelsMatchingTheirActions() {
+        let label = KeyLabelType.mainAndDirections(
+            "a",
+            CustardKeyDirectionalLabel(left: "b", top: "↑", right: "c", bottom: "D")
+        )
+        let flickMap: [FlickDirection: UnifiedVariation] = [
+            .left: UnifiedVariation(label: .text("b"), pressActions: [.input("b")]),
+            .top: UnifiedVariation(label: .text("↑"), pressActions: [.moveCursor(1)]),
+            .right: UnifiedVariation(label: .text("x"), pressActions: [.input("x")]),
+            .bottom: UnifiedVariation(label: .text("D"), pressActions: [.input("D")]),
+        ]
+
+        XCTAssertEqual(
+            label.uppercasedForEnglishIfInputMatches(
+                pressActions: [.input("a")],
+                flickMap: flickMap
+            ),
+            .mainAndDirections(
+                "A",
+                CustardKeyDirectionalLabel(left: "B", top: "↑", right: "c", bottom: "D")
+            )
+        )
+    }
+
+    func test_flickVariationLabelUsesItsOwnInputAction() {
+        let variation = UnifiedVariation(label: .text("b"), pressActions: [.input("b")])
+
+        XCTAssertEqual(
+            variation.uppercasedForEnglishIfInputMatches().label,
+            .text("B")
+        )
+    }
+}


### PR DESCRIPTION
## 概要
PCスタイルの英語カスタムタブで、ShiftまたはCaps Lock中に「メインと4方向」などの複合ラベルも大文字表示へ追従するようにします。

## 原因
実際の文字入力はShift状態に応じて大文字化されていましたが、表示側の対象判定と変換処理が単純なテキストラベルだけに限定されていました。そのため、ラベル形式を「メインと4方向」へ変更すると、入力は大文字になる一方で表示は小文字のままになっていました。

## 変更内容
- PCスタイルでは、ラベル形式にかかわらず各表示文字と対応アクションを個別に照合
- 以下の表示をShift/Caps Lockへ追従
  - 通常テキスト
  - 「メインとサブ」のメイン
  - 「メインと4方向」のメインと各方向
  - フリック操作中の候補ラベル
- フリック方向ごとに、その方向の入力アクションを使って判定

## 安全条件
次の条件をすべて満たす場合だけ大文字化します。

- PCスタイルの英語タブ
- ラベルが1文字
- 対応アクションが1つだけ
- 対応アクションが文字入力
- ラベルと入力文字が一致

装飾用ラベル、カーソル操作などの非入力アクション、入力文字と異なるラベルは変更しません。

## テスト
- 単純テキストの従来条件を維持
- 入力文字の不一致や複数アクションでは変換しない
- 「メインとサブ」ではメインだけを変換
- 「メインと4方向」では対応アクションが一致する方向だけを変換
- フリック候補が自身の入力アクションに基づいて変換されることを確認

## 動作確認
- AzooKeyCoreのiOSテストターゲットを含むビルド成功
- MainAppのiOS Simulator向けDebugビルド成功
- SwiftLint成功（0 violations）
- git diff --check成功